### PR TITLE
added policy statement for S3ReadWriteResource

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -1044,6 +1044,16 @@
                   "Ref" : "S3ReadWriteResource"
                 }
               ]
+            },
+            {
+              "Sid": "S3ReadWriteContents",
+              "Effect": "Allow",
+              "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:DeleteObject"
+              ],
+              "Resource": [{"Fn::Join" : [ "", [{"Ref" : "S3ReadWriteResource"}, "/", "*" ] ]}]
             }
           ]
         },


### PR DESCRIPTION
The S3ReadWriteResource only allowed operations on the bucket and not on the objects in the bucket. Added a second policy statement to allow put/get/delete on objects in the bucket.