### PR TITLE
Fix compute_subnet_id reference in docs, see #57

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -369,11 +369,11 @@ Defaults to NONE in the default template. ::
 
     additional_sg = sg-xxxxxx
 
-master_subnet_id
+compute_subnet_id
 """"""""""""""""
 ID of an existing subnet you want to provision the compute nodes into. ::
 
-    master_subnet_id = subnet-xxxxxx
+    compute_subnet_id = subnet-xxxxxx
 
 compute_subnet_cidr
 """""""""""""""""""


### PR DESCRIPTION
This was bugging me too, when I was looking to run master and compute in different subnets.