### PR TITLE
Improve logging of nodewatcher and sqswatcher

### DIFF
--- a/node/nodewatcher/nodewatcher.py
+++ b/node/nodewatcher/nodewatcher.py
@@ -25,10 +25,6 @@ import sys
 import tempfile
 import logging
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s'
-)
 log = logging.getLogger(__name__)
 
 def getConfig(instance_id):
@@ -137,6 +133,10 @@ def selfTerminate(region, asg, instance_id):
         _as_conn.terminate_instance(instance_id, decrement_capacity=True)
 
 def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s'
+    )
     log.info("nodewatcher startup")
     instance_id = getInstanceId()
     hostname = getHostname()

--- a/node/nodewatcher/nodewatcher.py
+++ b/node/nodewatcher/nodewatcher.py
@@ -23,12 +23,22 @@ import os
 import time
 import sys
 import tempfile
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s'
+)
+log = logging.getLogger(__name__)
 
 def getConfig(instance_id):
-    print('running getConfig')
+    log.debug('reading /etc/nodewatcher.cfg')
 
     config = ConfigParser.RawConfigParser()
     config.read('/etc/nodewatcher.cfg')
+    if config.has_option('nodewatcher', 'loglevel'):
+        lvl = logging._levelNames[config.get('nodewatcher', 'loglevel')]
+        logging.getLogger().setLevel(lvl)
     _region = config.get('nodewatcher', 'region')
     _scheduler = config.get('nodewatcher', 'scheduler')
     try:
@@ -37,6 +47,7 @@ def getConfig(instance_id):
         conn = boto.ec2.connect_to_region(_region,proxy=boto.config.get('Boto', 'proxy'),
                                           proxy_port=boto.config.get('Boto', 'proxy_port'))
         _asg = conn.get_all_instances(instance_ids=instance_id)[0].instances[0].tags['aws:autoscaling:groupName']
+        log.debug("discovered asg: %s" % _asg)
         config.set('nodewatcher', 'asg', _asg)
 
         tup = tempfile.mkstemp(dir=os.getcwd())
@@ -46,11 +57,10 @@ def getConfig(instance_id):
 
         os.rename(tup[1], 'nodewatcher.cfg')
 
+    log.debug("region=%s asg=%s scheduler=%s" % (_region, _asg, _scheduler))
     return _region, _asg, _scheduler
 
 def getHourPercentile(instance_id, conn):
-    print('running checkRunTime')
-
     _reservations = conn.get_all_instances(instance_ids=[instance_id])
     _instance = _reservations[0].instances[0]
     _launch_time = dateutil.parser.parse(_instance.launch_time).replace(tzinfo=None)
@@ -59,6 +69,9 @@ def getHourPercentile(instance_id, conn):
     _delta_in_hours = _delta.seconds / 3600.0
     _hour_percentile = (_delta_in_hours % 1) * 100
 
+    log.debug("launch=%s delta=%s percentile=%s" % (_launch_time, _delta,
+                                                    _hour_percentile))
+
     return _hour_percentile
 
 def getInstanceId():
@@ -66,8 +79,10 @@ def getInstanceId():
     try:
         _instance_id = urllib2.urlopen("http://169.254.169.254/latest/meta-data/instance-id").read()
     except urllib2.URLError:
-        print('Unable to get instance-id from metadata')
+        log.critical('Unable to get instance-id from metadata')
         sys.exit(1)
+
+    log.debug("instance_id=%s" % _instance_id)
 
     return _instance_id
 
@@ -76,17 +91,19 @@ def getHostname():
     try:
         _hostname = urllib2.urlopen("http://169.254.169.254/latest/meta-data/local-hostname").read()
     except urllib2.URLError:
-        print('Unable to get hostname from metadata')
+        log.critical('Unable to get hostname from metadata')
         sys.exit(1)
+
+    log.debug("hostname=%s" % _hostname)
 
     return _hostname
 
 def loadSchedulerModule(scheduler):
-    print 'running loadSchedulerModule'
-
     scheduler = 'nodewatcher.plugins.' + scheduler
     _scheduler = __import__(scheduler)
     _scheduler = sys.modules[scheduler]
+
+    log.debug("scheduler=%s" % repr(_scheduler))
 
     return _scheduler
 
@@ -94,9 +111,14 @@ def getJobs(s,hostname):
 
     _jobs = s.getJobs(hostname)
 
+    log.debug("jobs=%s" % _jobs)
+
     return _jobs
 
 def lockHost(s,hostname,unlock=False):
+    log.debug("%s %s" % (unlock and "unlocking" or "locking",
+                         hostname))
+
     _r = s.lockHost(hostname, unlock)
 
     time.sleep(15) # allow for some settling
@@ -109,11 +131,13 @@ def selfTerminate(region, asg, instance_id):
     _asg = _as_conn.get_all_groups(names=[asg])[0]
     _capacity = _asg.desired_capacity
     _min_size = _asg.min_size
+    log.debug("capacity=%d min_size=%d" % (_capacity, _min_size))
     if _capacity > _min_size:
+        log.info("terminating %s" % instance_id)
         _as_conn.terminate_instance(instance_id, decrement_capacity=True)
 
 def main():
-    print('Running __main__')
+    log.info("nodewatcher startup")
     instance_id = getInstanceId()
     hostname = getHostname()
     region, asg, scheduler = getConfig(instance_id)
@@ -124,20 +148,20 @@ def main():
         time.sleep(60)
         conn = boto.ec2.connect_to_region(region)
         hour_percentile = getHourPercentile(instance_id,conn)
-        print('Percent of hour used: %d' % hour_percentile)
+        log.info('Percent of hour used: %d' % hour_percentile)
 
         if hour_percentile < 95:
             continue
         
         jobs = getJobs(s, hostname)
         if jobs == True:
-            print('Instance has active jobs.')
+            log.info('Instance has active jobs.')
         else:
             # avoid race condition by locking and verifying
             lockHost(s, hostname)
             jobs = getJobs(s, hostname)
             if jobs == True:
-                print ('Instance actually has active jobs.')
+                log.info('Instance actually has active jobs.')
                 lockHost(s, hostname, unlock=True)
                 continue
             else:

--- a/node/nodewatcher/plugins/openlava.py
+++ b/node/nodewatcher/plugins/openlava.py
@@ -13,6 +13,9 @@ __author__ = 'dougalb'
 
 import subprocess
 import os
+import logging
+
+log = logging.getLogger(__name__)
 
 def getJobs(hostname):
     # Checking for running jobs on the node
@@ -20,7 +23,7 @@ def getJobs(hostname):
     try:
        output = subprocess.Popen(command, stdout=subprocess.PIPE).communicate()[0]
     except subprocess.CalledProcessError:
-        print ("Failed to run %s\n" % _command)
+        log.error("Failed to run %s\n" % _command)
 
     if output == "":
         _jobs = False
@@ -39,5 +42,5 @@ def lockHost(hostname, unlock=False):
             env=dict(os.environ, SGE_ROOT='/opt/sge',
                      PATH='/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'))
     except subprocess.CalledProcessError:
-        print ("Failed to run %s\n" % command)
+        log.error("Failed to run %s\n" % command)
 

--- a/node/nodewatcher/plugins/sge.py
+++ b/node/nodewatcher/plugins/sge.py
@@ -13,6 +13,9 @@ __author__ = 'dougalb'
 
 import subprocess
 import os
+import logging
+
+log = logging.getLogger(__name__)
 
 def getJobs(hostname):
     # Checking for running jobs on the node
@@ -22,7 +25,7 @@ def getJobs(hostname):
                                  env=dict(os.environ, SGE_ROOT='/opt/sge',
                                          PATH='/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin')).communicate()[0]
     except subprocess.CalledProcessError:
-        print ("Failed to run %s\n" % command)
+        log.error("Failed to run %s\n" % command)
 
     _jobs = True
     for host in _output.split('\n'):
@@ -41,5 +44,5 @@ def lockHost(hostname, unlock=False):
             env=dict(os.environ, SGE_ROOT='/opt/sge',
                      PATH='/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'))
     except subprocess.CalledProcessError:
-        print ("Failed to run %s\n" % command)
+        log.error("Failed to run %s\n" % command)
 

--- a/node/nodewatcher/plugins/torque.py
+++ b/node/nodewatcher/plugins/torque.py
@@ -13,6 +13,9 @@ __author__ = 'dougalb'
 
 import subprocess
 import os
+import logging
+
+log = logging.getLogger(__name__)
 
 def runPipe(cmds):
     try:
@@ -36,9 +39,9 @@ def getJobs(hostname):
     # Checking for running jobs on the node
     commands = ['/opt/torque/bin/qstat -r -n -1', ('grep ' + hostname.split('.')[0])]
     try:
-       status, output = runPipe(commands)
+        status, output = runPipe(commands)
     except subprocess.CalledProcessError:
-        print ("Failed to run %s\n" % _command)
+        log.error("Failed to run %s\n" % _command)
 
     if output == "":
         _jobs = False
@@ -57,5 +60,5 @@ def lockHost(hostname, unlock=False):
             env=dict(os.environ, SGE_ROOT='/opt/sge',
                      PATH='/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'))
     except subprocess.CalledProcessError:
-        print ("Failed to run %s\n" % command)
+        log.error("Failed to run %s\n" % command)
 

--- a/node/sqswatcher/plugins/openlava.py
+++ b/node/sqswatcher/plugins/openlava.py
@@ -14,17 +14,21 @@ __author__ = 'dougalb'
 import subprocess as sub
 import os
 import paramiko
+import logging
+
+log = logging.getLogger(__name__)
 
 def __runOpenlavaCommand(command):
+    log.debug(repr(command))
     _command = command
     try:
         sub.check_call(_command, env=dict(os.environ, LSF_ENVDIR='/opt/openlava/etc'))
     except sub.CalledProcessError:
-        print ("Failed to run %s\n" % _command)
+        log.error("Failed to run %s\n" % _command)
 
 
 def addHost(hostname, cluster_user):
-    print('Adding %s', hostname)
+    log.info('Adding %s', hostname)
 
     command = ['/opt/openlava/bin/lsaddhost', '-t', 'linux', '-m', 'IntelXeon', hostname]
 
@@ -39,15 +43,15 @@ def addHost(hostname, cluster_user):
     connected=False
     while iter < 3 and connected == False:
         try:
-            print('Connecting to host: %s iter: %d' % (hostname, iter))
+            log.info('Connecting to host: %s iter: %d' % (hostname, iter))
             ssh.connect(hostname, username=cluster_user, key_filename=user_key_file)
             connected=True
         except socket.error, e:
-            print('Socket error: %s' % e)
+            log.error('Socket error: %s' % e)
             time.sleep(10 + iter)
             iter = iter + 1
             if iter == 3:
-               print("Unable to provison host")
+               log.critical("Unable to provison host")
                return
     try:
         ssh.load_host_keys(hosts_key_file)
@@ -58,7 +62,7 @@ def addHost(hostname, cluster_user):
     ssh.close()
 
 def removeHost(hostname,cluster_user):
-    print('Removing %s', hostname)
+    log.info('Removing %s', hostname)
 
     command = ['/opt/openlava/bin/lsrmhost', hostname]
 

--- a/node/sqswatcher/plugins/sge.py
+++ b/node/sqswatcher/plugins/sge.py
@@ -17,16 +17,20 @@ from tempfile import NamedTemporaryFile
 import time
 import os
 import socket
+import logging
+
+log = logging.getLogger(__name__)
 
 def __runSgeCommand(command):
+    log.debug(repr(command))
     _command = command
     try:
         sub.check_call(_command, env=dict(os.environ, SGE_ROOT='/opt/sge'))
     except sub.CalledProcessError:
-        print ("Failed to run %s\n" % _command)
+        log.error("Failed to run %s\n" % _command)
 
 def addHost(hostname, cluster_user):
-    print('Adding %s', hostname)
+    log.info('Adding %s', hostname)
 
     # Adding host as administrative host
     command = ['/opt/sge/bin/lx-amd64/qconf', '-ah', hostname]
@@ -63,15 +67,15 @@ report_variables      NONE
     connected=False
     while iter < 3 and connected == False:
         try:
-            print('Connecting to host: %s iter: %d' % (hostname, iter))
+            log.info('Connecting to host: %s iter: %d' % (hostname, iter))
             ssh.connect(hostname, username=cluster_user, key_filename=user_key_file)
             connected=True
         except socket.error, e:
-            print('Socket error: %s' % e)
+            log.error('Socket error: %s' % e)
             time.sleep(10 + iter)
             iter = iter + 1
             if iter == 3:
-               print("Unable to provison host")
+               log.critical("Unable to provison host")
                return
     try:
         ssh.load_host_keys(hosts_key_file)
@@ -84,7 +88,7 @@ report_variables      NONE
     ssh.close()
 
 def removeHost(hostname,cluster_user):
-    print('Removing %s', hostname)
+    log.info('Removing %s', hostname)
 
     # Purge hostname from all.q
     command = ['/opt/sge/bin/lx-amd64/qconf', '-purge', 'queue', '*', 'all.q@%s' % hostname]

--- a/node/sqswatcher/plugins/test.py
+++ b/node/sqswatcher/plugins/test.py
@@ -11,18 +11,22 @@
 
 __author__ = 'dougalb'
 
+import logging
+
+log = logging.getLogger(__name__)
+
 hostfile_path = 'sqswatcher.hosts'
 
 def addHost(hostname,cluster_user):
     if hostname != None:
-        print('Adding', hostname)
+        log.info('Adding', hostname)
         hostfile = open(hostfile_path, 'a')
         print >> hostfile, hostname
         hostfile.close()
 
 def removeHost(hostname,cluster_user):
     if hostname != None:
-        print('Removing', hostname)
+        log.info('Removing', hostname)
         hostfile = open(hostfile_path, 'r')
         lines = hostfile.readlines()
         hostfile.close()

--- a/node/sqswatcher/plugins/torque.py
+++ b/node/sqswatcher/plugins/torque.py
@@ -14,17 +14,21 @@ __author__ = 'dougalb'
 import subprocess as sub
 import os
 import paramiko
+import logging
+
+log = logging.getLogger(__name__)
 
 def __runCommand(command):
+    log.debug(repr(command))
     _command = command
     try:
         sub.check_call(_command, env=dict(os.environ))
     except sub.CalledProcessError:
-        print ("Failed to run %s\n" % _command)
+        log.error("Failed to run %s\n" % _command)
 
 
 def addHost(hostname,cluster_user):
-    print('Adding %s', hostname)
+    log.info('Adding %s', hostname)
 
     command = ['/opt/torque/bin/qmgr', '-c', ('create node %s' % hostname)]
     __runCommand(command)
@@ -41,15 +45,15 @@ def addHost(hostname,cluster_user):
     connected=False
     while iter < 3 and connected == False:
         try:
-            print('Connecting to host: %s iter: %d' % (hostname, iter))
+            log.info('Connecting to host: %s iter: %d' % (hostname, iter))
             ssh.connect(hostname, username=cluster_user, key_filename=user_key_file)
             connected=True
         except socket.error, e:
-            print('Socket error: %s' % e)
+            log.info('Socket error: %s' % e)
             time.sleep(10 + iter)
             iter = iter + 1
             if iter == 3:
-               print("Unable to provison host")
+               log.info("Unable to provison host")
                return
     try:
         ssh.load_host_keys(hosts_key_file)
@@ -63,7 +67,7 @@ def addHost(hostname,cluster_user):
     __runCommand(command)
 
 def removeHost(hostname, cluster_user):
-    print('Removing %s', hostname)
+    log.info('Removing %s', hostname)
 
     command = ['/opt/torque/bin/pbsnodes', '-o', hostname]
     __runCommand(command)

--- a/node/sqswatcher/sqswatcher.py
+++ b/node/sqswatcher/sqswatcher.py
@@ -120,7 +120,7 @@ def pollQueue(scheduler, q, t):
 
                 if eventType != 'autoscaling:TEST_NOTIFICATION':
                     instanceId = message_attrs['EC2InstanceId']
-                    log.info("instanceId=" % instanceId)
+                    log.info("instanceId=%s" % instanceId)
                     if eventType == 'cfncluster:COMPUTE_READY':
                         ec2 = boto.connect_ec2()
                         ec2 = boto.ec2.connect_to_region(region,proxy=boto.config.get('Boto', 'proxy'),

--- a/node/sqswatcher/sqswatcher.py
+++ b/node/sqswatcher/sqswatcher.py
@@ -28,10 +28,6 @@ from boto.sqs.message import RawMessage
 from boto.dynamodb2.fields import HashKey
 from boto.dynamodb2.table import Table
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s'
-)
 log = logging.getLogger(__name__)
 
 def getConfig():
@@ -180,6 +176,10 @@ def pollQueue(scheduler, q, t):
         time.sleep(30)
 
 def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s'
+    )
     log.info("sqswatcher startup")
     global region, cluster_user
     region, sqsqueue, table_name, scheduler, cluster_user = getConfig()


### PR DESCRIPTION
When debugging problems with either nodewatcher or sqswatcher, the previous logging system (print statements mostly) left some things to be desired. This PR switches logging to use the common Python logging framework. Log level can be adjusted by an optional `loglevel=` setting in `nodewatcher.cfg` and `sqswatcher.cfg`.