### PR TITLE
fixed bug in cloudformation template preventing extra_json from being provided to chef cookbooks

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -1952,7 +1952,7 @@
                 "command" : "touch /etc/chef/ohai/hints/ec2.json"
               },
               "jq" : {
-                "command" : "/usr/local/bin/jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster' > /etc/chef/dna.json || echo \"jq not installed\"; cp /tmp/dna.json /etc/chef/dna.json"
+                "command" : "/usr/local/bin/jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster' > /etc/chef/dna.json || ( echo \"jq not installed\"; cp /tmp/dna.json /etc/chef/dna.json )"
               }
             }
           },


### PR DESCRIPTION
command was always blowing away /etc/chef/dna.json with /tmp/dna.jsaon, causing /tmp/extra.json to be ignored.