### PR TITLE
Add missing parameters to cfnconfig

### DIFF
--- a/cli/cfncluster/cfnconfig.py
+++ b/cli/cfncluster/cfnconfig.py
@@ -209,7 +209,8 @@ class CfnClusterConfig:
                                       cwl_log_group=('CWLLogGroup',None),shared_dir=('SharedDir',None),tenancy=('Tenancy',None),
                                       ephemeral_kms_key_id=('EphemeralKMSKeyId',None), cluster_ready=('ClusterReadyScript','URL'),
                                       master_root_volume_size=('MasterRootVolumeSize',None),compute_root_volume_size=('ComputeRootVolumeSize',None),
-                                      base_os=('BaseOS',None),ec2_iam_role=('EC2IAMRoleName',None),extra_json=('ExtraJson',None)
+                                      base_os=('BaseOS',None),ec2_iam_role=('EC2IAMRoleName',None),extra_json=('ExtraJson',None),
+                                      custom_chef_cookbook=('CustomChefCookbook',None),custom_chef_runlist=('CustomChefRunList',None)
                                       )
 
         # Loop over all the cluster options and add define to parameters, raise Exception if defined but null


### PR DESCRIPTION
The CustomChefCookbook and CustomChefRunList parameters are present in the stock cfncluster.cfn.json, but are not pulled in from the cfncluster config file. This PR adds the missing arguments.