### PR TITLE
Corrected incorrect example for cfncluster delete

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -108,7 +108,7 @@ optional arguments:
 
 ::
 
-    $ cfncluster update mycluster
+    $ cfncluster delete mycluster
 
 status
 ======


### PR DESCRIPTION
The `cfncluster delete` command example incorrectly showed `cfncluster update`.