### PR TITLE
Move ReadTheDocs links to HTTPS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ CfnCluster ("cloud formation cluster") is a framework that deploys and maintains
 Documentation
 =============
 
-Documentation is part of the project and is published to - http://cfncluster.readthedocs.io/. Of most interest to new users is the Getting Started Guide - http://cfncluster.readthedocs.io/en/latest/getting_started.html.
+Documentation is part of the project and is published to - https://cfncluster.readthedocs.io/. Of most interest to new users is the Getting Started Guide - https://cfncluster.readthedocs.io/en/latest/getting_started.html.
 
 Issues
 ======

--- a/docs/source/ami_development.rst
+++ b/docs/source/ami_development.rst
@@ -83,7 +83,7 @@ The next part of setting up your environment involves setting a lot of environme
 
 		export AWS_SECURITY_GROUP_ID=sg-XXXXXXXX
 
-#.	Create an IAM Profile from the template `here <http://cfncluster.readthedocs.io/en/latest/iam.html>`_.
+#.	Create an IAM Profile from the template `here <https://cfncluster.readthedocs.io/en/latest/iam.html>`_.
 
 	::
 

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -14,7 +14,7 @@ Most commands provided are just wrappers around CloudFormation functions.
 create
 ======
 
-Creates a CloudFormation stack with the name :code:`cfncluster-[stack_name]`. To read more about CloudFormation see `AWS CloudFormation <http://cfncluster.readthedocs.io/en/latest/aws_services.html#aws-cloudformation>`_.
+Creates a CloudFormation stack with the name :code:`cfncluster-[stack_name]`. To read more about CloudFormation see `AWS CloudFormation <https://cfncluster.readthedocs.io/en/latest/aws_services.html#aws-cloudformation>`_.
 
 positional arguments:
   cluster_name          create a cfncluster with the provided name.
@@ -80,7 +80,7 @@ optional arguments:
 start
 =====
 
-Starts a cluster. This starts the Master Server and sets Auto Scaling Group parameters to :code:`min/max/desired = 0/max_queue_size/0` where `max_queue_size <http://cfncluster.readthedocs.io/en/latest/configuration.html#max-queue-size>`_ defaults to 10. If you specify the :code:`--reset-desired` flag, the :code:`min/desired` values will be set to the `initial_queue_size <http://cfncluster.readthedocs.io/en/latest/configuration.html#initial-queue-size>`_. Since the EC2 instances in the compute fleet try and mount the nfs drive from the master server this causes a race condition such that if the master server starts after the compute nodes, the compute nodes will terminate since they can't mount the nfs drive.
+Starts a cluster. This starts the Master Server and sets Auto Scaling Group parameters to :code:`min/max/desired = 0/max_queue_size/0` where `max_queue_size <https://cfncluster.readthedocs.io/en/latest/configuration.html#max-queue-size>`_ defaults to 10. If you specify the :code:`--reset-desired` flag, the :code:`min/desired` values will be set to the `initial_queue_size <https://cfncluster.readthedocs.io/en/latest/configuration.html#initial-queue-size>`_. Since the EC2 instances in the compute fleet try and mount the nfs drive from the master server this causes a race condition such that if the master server starts after the compute nodes, the compute nodes will terminate since they can't mount the nfs drive.
 
 positional arguments:
   cluster_name          start a cfncluster with the provided name.
@@ -156,7 +156,7 @@ optional arguments:
 configure
 =========
 
-Configures the cluster. See `Configuring CfnCluster <http://cfncluster.readthedocs.io/en/latest/getting_started.html#configuring-cfncluster>`_.
+Configures the cluster. See `Configuring CfnCluster <https://cfncluster.readthedocs.io/en/latest/getting_started.html#configuring-cfncluster>`_.
 
 optional arguments:
   -h, --help  show this help message and exit

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -205,7 +205,7 @@ html_theme_options = {
     "bind_key_events": False,
     # Specify a base_url used to generate sitemap.xml links. If not
     # specified, then no sitemap will be built.
-    "base_url": "http://cfncluster.readthedocs.org/lastet/"
+    "base_url": "https://cfncluster.readthedocs.io/latest/"
 }
 
 

--- a/docs/staging/README
+++ b/docs/staging/README
@@ -1,2 +1,2 @@
-This directoy contains draft documentation. Once complete, they are moved
-to http://cfncluster.readthedocs.org/
+This directory contains draft documentation. Once complete, they are moved
+to https://cfncluster.readthedocs.io/


### PR DESCRIPTION
Because it's 2017. Also fixed a couple of `.org` links that were left around.