### PR TITLE
Add support for Python 3

### DIFF
--- a/cli/cfncluster/cfncluster.py
+++ b/cli/cfncluster/cfncluster.py
@@ -19,13 +19,13 @@ import os
 import socket
 import logging
 
-import cfnconfig
+from . import cfnconfig
 
 logger = logging.getLogger('cfncluster.cfncluster')
 
 def version(args):
     config = cfnconfig.CfnClusterConfig(args)
-    print config.version
+    print(config.version)
 
 def create(args):
     print('Starting: %s' % (args.cluster_name))
@@ -50,7 +50,7 @@ def create(args):
                                                  aws_secret_access_key=config.aws_secret_access_key)
             availability_zone = str(vpcconn.get_all_subnets(subnet_ids=master_subnet_id)[0].availability_zone)
         except boto.exception.BotoServerError as e:
-            print e.message
+            print(e.message)
             sys.exit(1)
         config.parameters.append(('AvailabilityZone', availability_zone))
     except ValueError:
@@ -73,14 +73,15 @@ def create(args):
                 sys.stdout.write('\r%s' % resource_status)
                 sys.stdout.flush()
                 time.sleep(5)
+                print("")
             outputs = cfnconn.describe_stacks(stack)[0].outputs
             for output in outputs:
-                print output
+                print(output)
         else:
             status = cfnconn.describe_stacks(stack)[0].stack_status
             print('Status: %s' % status)
     except boto.exception.BotoServerError as e:
-        print e.message
+        print(e.message)
         sys.exit(1)
     except KeyboardInterrupt:
         print('\nExiting...')
@@ -118,7 +119,7 @@ def update(args):
                                                  aws_secret_access_key=config.aws_secret_access_key)
             availability_zone = str(vpcconn.get_all_subnets(subnet_ids=master_subnet_id)[0].availability_zone)
         except boto.exception.BotoServerError as e:
-            print e.message
+            print(e.message)
             sys.exit(1)
         config.parameters.append(('AvailabilityZone', availability_zone))
     except ValueError:
@@ -142,7 +143,7 @@ def update(args):
             status = cfnconn.describe_stacks(stack)[0].stack_status
             print('Status: %s' % status)
     except boto.exception.BotoServerError as e:
-        print e.message
+        print(e.message)
         sys.exit(1)
     except KeyboardInterrupt:
         print('\nExiting...')
@@ -161,7 +162,7 @@ def start(args):
         response = ec2conn.start_instances(master_server_id)
     except boto.exception.BotoServerError as e:
         if e.message.endswith("does not exist"):
-            print e.message
+            print(e.message)
             sys.stdout.flush()
             sys.exit(0)
         else:
@@ -201,7 +202,7 @@ def stop(args):
         response = ec2conn.stop_instances(master_server_id)
     except boto.exception.BotoServerError as e:
         if e.message.endswith("does not exist"):
-            print e.message
+            print(e.message)
             sys.stdout.flush()
             sys.exit(0)
         else:
@@ -224,7 +225,7 @@ def list(args):
                 print('%s' % (stack.stack_name[11:]))
     except boto.exception.BotoServerError as e:
         if e.message.endswith("does not exist"):
-            print e.message
+            print(e.message)
         else:
             raise e
     except KeyboardInterrupt:
@@ -243,7 +244,7 @@ def get_master_server_id(stack_name, config):
             resources = cfnconn.describe_stack_resources(stack_name)
         except boto.exception.BotoServerError as e:
             if e.message.endswith("does not exist"):
-                print e.message
+                print(e.message)
                 sys.stdout.flush()
                 sys.exit(0)
             else:
@@ -280,7 +281,7 @@ def poll_master_server_state(stack_name, config):
         sys.stdout.flush()
     except boto.exception.BotoServerError as e:
         if e.message.endswith("does not exist"):
-            print e.message
+            print(e.message)
             sys.stdout.flush()
             sys.exit(0)
         else:
@@ -303,7 +304,7 @@ def get_ec2_instances(stack, config):
         except boto.exception.BotoServerError as e:
             if e.message.endswith("does not exist"):
                 #sys.stdout.write('\r\n')
-                print e.message
+                print(e.message)
                 sys.stdout.flush()
                 sys.exit(0)
             else:
@@ -334,7 +335,7 @@ def get_asg(stack_name, config):
         return asgconn.get_all_groups(names=[asg_id])[0]
     except boto.exception.BotoServerError as e:
         if e.message.endswith("does not exist"):
-            print e.message
+            print(e.message)
             sys.stdout.flush()
             sys.exit(0)
         else:
@@ -363,7 +364,7 @@ def get_asg_ids(stack, config):
         except boto.exception.BotoServerError as e:
             if e.message.endswith("does not exist"):
                 #sys.stdout.write('\r\n')
-                print e.message
+                print(e.message)
                 sys.stdout.flush()
                 sys.exit(0)
             else:
@@ -433,22 +434,22 @@ def status(args):
                 if state == 'running':
                     outputs = cfnconn.describe_stacks(stack)[0].outputs
                     for output in outputs:
-                        print output
+                        print(output)
             elif ((status == 'ROLLBACK_COMPLETE') or (status == 'CREATE_FAILED') or (status == 'DELETE_FAILED') or
                       (status == 'UPDATE_ROLLBACK_COMPLETE')):
                 events = cfnconn.describe_stack_events(stack)
                 for event in events:
                     if ((event.resource_status == 'CREATE_FAILED') or (event.resource_status == 'DELETE_FAILED') or
                             (event.resource_status == 'UPDATE_FAILED')):
-                        print event.timestamp, event.resource_status, event.resource_type, event.logical_resource_id, \
-                            event.resource_status_reason
+                        print(event.timestamp, event.resource_status, event.resource_type, event.logical_resource_id, \
+                            event.resource_status_reason)
         else:
             sys.stdout.write('\n')
             sys.stdout.flush()
     except boto.exception.BotoServerError as e:
         if e.message.endswith("does not exist"):
             sys.stdout.write('\r')
-            print e.message
+            print(e.message)
             sys.stdout.flush()
             sys.exit(0)
         else:
@@ -489,7 +490,7 @@ def delete(args):
     except boto.exception.BotoServerError as e:
         if e.message.endswith("does not exist"):
             #sys.stdout.write('\r\n')
-            print e.message
+            print(e.message)
             sys.stdout.flush()
             sys.exit(0)
         else:

--- a/cli/cfncluster/cfnconfig.py
+++ b/cli/cfncluster/cfnconfig.py
@@ -9,15 +9,21 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ConfigParser
 import os
 import sys
 import inspect
 import pkg_resources
 import json
-import urllib2
-import config_sanity
 import boto.cloudformation
+
+from . import config_sanity
+
+if sys.version_info.major < 3:
+    import ConfigParser as configparser
+    import urllib2
+else:
+    import configparser
+    from urllib.request import urlopen
 
 def getStackTemplate(region, aws_access_key_id, aws_secret_access_key, stack):
 
@@ -36,7 +42,7 @@ class CfnClusterConfig:
         self.parameters = []
         self.version = pkg_resources.get_distribution("cfncluster").version
         self.__DEFAULT_CONFIG = False
-        __args_func = self.args.func.func_name
+        __args_func = self.args.func.__name__
 
         # Determine config file name based on args or default
         if args.config_file is not None:
@@ -58,7 +64,7 @@ class CfnClusterConfig:
                 sys.exit(1)
 
 
-        __config = ConfigParser.ConfigParser()
+        __config = configparser.ConfigParser()
         __config.read(self.__config_file)
 
         # Determine the EC2 region to used used or default to us-east-1
@@ -71,17 +77,17 @@ class CfnClusterConfig:
             else:
                 try:
                     self.region = __config.get('aws', 'aws_region_name')
-                except ConfigParser.NoOptionError:
+                except configparser.NoOptionError:
                     self.region = 'us-east-1'
 
         # Check if credentials have been provided in config
         try:
             self.aws_access_key_id = __config.get('aws', 'aws_access_key_id')
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             self.aws_access_key_id=None
         try:
             self.aws_secret_access_key = __config.get('aws', 'aws_secret_access_key')
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             self.aws_secret_access_key=None
 
         # Determine which cluster template will be used
@@ -102,12 +108,12 @@ class CfnClusterConfig:
         # Check if package updates should be checked
         try:
             self.__update_check = __config.getboolean('global', 'update_check')
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             self.__update_check = True
 
         if self.__update_check == True:
             try:
-                __latest = json.loads(urllib2.urlopen("http://pypi.python.org/pypi/cfncluster/json").read())['info']['version']
+                __latest = json.loads(urlopen("http://pypi.python.org/pypi/cfncluster/json").read())['info']['version']
                 if self.version < __latest:
                     print('warning: There is a newer version %s of cfncluster available.' % __latest)
             except Exception:
@@ -116,10 +122,10 @@ class CfnClusterConfig:
         # Check if config sanity should be run
         try:
             self.__sanity_check = __config.getboolean('global', 'sanity_check')
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             self.__sanity_check = False
         # Only check config on calls that mutate it
-        __args_func = self.args.func.func_name
+        __args_func = self.args.func.__name__
         if (__args_func == 'create' or __args_func == 'update' or __args_func == 'configure') and self.__sanity_check is True:
             pass
         else:
@@ -134,7 +140,7 @@ class CfnClusterConfig:
             if self.__sanity_check:
                 config_sanity.check_resource(self.region,self.aws_access_key_id, self.aws_secret_access_key,
                                              'EC2KeyPair', self.key_name)
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             print("ERROR: Missing key_name option in [%s] section." % self.__cluster_section)
             sys.exit(1)
         self.parameters.append(('KeyName', self.key_name))
@@ -153,7 +159,7 @@ class CfnClusterConfig:
                 if self.__sanity_check:
                     config_sanity.check_resource(self.region,self.aws_access_key_id, self.aws_secret_access_key,
                                              'URL', self.template_url)
-            except ConfigParser.NoOptionError:
+            except configparser.NoOptionError:
                 if self.region == 'us-gov-west-1':
                     self.template_url = ('https://s3-%s.amazonaws.com/cfncluster-%s/templates/cfncluster-%s.cfn.json'
                                          % (self.region, self.region, self.version))
@@ -189,7 +195,7 @@ class CfnClusterConfig:
                     config_sanity.check_resource(self.region,self.aws_access_key_id, self.aws_secret_access_key,
                                                 self.__vpc_options.get(key)[1],__temp__)
                 self.parameters.append((self.__vpc_options.get(key)[0],__temp__))
-            except ConfigParser.NoOptionError:
+            except configparser.NoOptionError:
                 pass
 
         # Dictionary list of all cluster section options
@@ -223,7 +229,7 @@ class CfnClusterConfig:
                     config_sanity.check_resource(self.region,self.aws_access_key_id, self.aws_secret_access_key,
                                                 self.__cluster_options.get(key)[1],__temp__)
                 self.parameters.append((self.__cluster_options.get(key)[0],__temp__))
-            except ConfigParser.NoOptionError:
+            except configparser.NoOptionError:
                 pass
 
         # Merge tags from config with tags from command line args
@@ -232,7 +238,7 @@ class CfnClusterConfig:
         try:
             tags = __config.get(self.__cluster_section, 'tags')
             self.tags = json.loads(tags);
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             pass
         try:
             if args.tags is not None:
@@ -249,7 +255,7 @@ class CfnClusterConfig:
                                                 % self.__cluster_section)
                 sys.exit(1)
             self.__ebs_section = ('ebs %s' % self.__ebs_settings)
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             pass
 
         # Dictionary list of all EBS options
@@ -272,7 +278,7 @@ class CfnClusterConfig:
                             config_sanity.check_resource(self.region,self.aws_access_key_id, self.aws_secret_access_key,
                                                 self.__ebs_options.get(key)[1],__temp__)
                         self.parameters.append((self.__ebs_options.get(key)[0],__temp__))
-                    except ConfigParser.NoOptionError:
+                    except configparser.NoOptionError:
                         pass
         except AttributeError:
             pass
@@ -285,7 +291,7 @@ class CfnClusterConfig:
                                                 % self.__cluster_section)
                 sys.exit(1)
             self.__scaling_section = ('scaling %s' % self.__scaling_settings)
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             pass
 
         # Dictionary list of all scaling options
@@ -307,7 +313,7 @@ class CfnClusterConfig:
                             config_sanity.check_resource(self.region,self.aws_access_key_id, self.aws_secret_access_key,
                                                 self.__scaling_options.get(key)[1],__temp__)
                         self.parameters.append((self.__scaling_options.get(key)[0],__temp__))
-                    except ConfigParser.NoOptionError:
+                    except configparser.NoOptionError:
                         pass
         except AttributeError:
             pass

--- a/cli/cfncluster/cli.py
+++ b/cli/cfncluster/cli.py
@@ -16,8 +16,8 @@ import logging
 import platform
 import json
 
-import cfncluster
-import easyconfig
+from . import cfncluster
+from . import easyconfig
 
 def create(args):
     cfncluster.create(args)

--- a/cli/cfncluster/cli.py
+++ b/cli/cfncluster/cli.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import os
+import sys
 import argparse
 import logging
 import platform
@@ -148,6 +149,11 @@ def main():
 
     pversion = subparsers.add_parser('version', help='display version of cfncluster')
     pversion.set_defaults(func=version)
+
+    # if no arguments are given display help message
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
 
     args = parser.parse_args()
     logging.debug(args)

--- a/cli/cfncluster/config_sanity.py
+++ b/cli/cfncluster/config_sanity.py
@@ -13,10 +13,16 @@ __author__ = 'dougalb'
 
 import boto.ec2
 import boto.vpc
-import urllib2
-from urlparse import urlparse
 import boto.exception
 import sys
+
+if sys.version_info.major < 3:
+    from urllib2 import urlopen, HTTPError, URLError
+    from urlparse import urlparse
+else:
+    from urllib.request import urlopen
+    from urllib.error import HTTPError, URLError
+    from urllib.parse import urlparse
 
 def check_resource(region, aws_access_key_id, aws_secret_access_key, resource_type,resource_value):
 
@@ -92,11 +98,11 @@ def check_resource(region, aws_access_key_id, aws_secret_access_key, resource_ty
             pass
         else:
             try:
-                urllib2.urlopen(resource_value)
-            except urllib2.HTTPError, e:
+                urlopen(resource_value)
+            except HTTPError as e:
                 print(e.code)
                 sys.exit(1)
-            except urllib2.URLError, e:
+            except URLError as e:
                 print(e.args)
                 sys.exit(1)
     # EC2 EBS Snapshot Id

--- a/cli/cfncluster/easyconfig.py
+++ b/cli/cfncluster/easyconfig.py
@@ -9,14 +9,19 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ConfigParser
 import sys
 import boto.ec2
 import boto.vpc
 import os
 import logging
 
-import cfnconfig
+if sys.version_info.major < 3:
+    import ConfigParser as configparser
+    input = raw_input
+else:
+    import configparser
+
+from . import cfnconfig
 
 logger = logging.getLogger('cfncluster.cfncluster')
 
@@ -31,11 +36,11 @@ def prompt(prompt, default_value=None, hidden=False, options=None):
             user_prompt = user_prompt + ']: '
 
     if isinstance(options, list):
-        print 'Acceptable Values for %s: ' % prompt
+        print('Acceptable Values for %s: ' % prompt)
         for o in options:
-            print '    %s' % o
+            print('    %s' % o)
 
-    var = raw_input(user_prompt)
+    var = input(user_prompt)
 
     if var == '':
         return default_value
@@ -79,8 +84,8 @@ def list_keys(aws_access_key_id, aws_secret_access_key, aws_region_name):
         keynames.append(key.name)
 
     if not keynames:
-        print 'ERROR: No keys found in region ' + aws_region_name
-        print 'Please create an EC2 keypair before continuing'
+        print('ERROR: No keys found in region ' + aws_region_name)
+        print('Please create an EC2 keypair before continuing')
         sys.exit(1)
 
     return keynames
@@ -93,8 +98,8 @@ def list_vpcs(aws_access_key_id, aws_secret_access_key, aws_region_name):
         vpcids.append(vpc.id)
 
     if not vpcids:
-        print 'ERROR: No vpcs found in region ' + aws_region_name
-        print 'Please create an EC2 vpcpair before continuing'
+        print('ERROR: No vpcs found in region ' + aws_region_name)
+        print('Please create an EC2 vpcpair before continuing')
         sys.exit(1)
 
     return vpcids
@@ -107,8 +112,8 @@ def list_subnets(aws_access_key_id, aws_secret_access_key, aws_region_name, vpc_
         subnetids.append(subnet.id)
 
     if not subnetids:
-        print 'ERROR: No subnets found in region ' + aws_region_name
-        print 'Please create an EC2 subnetpair before continuing'
+        print('ERROR: No subnets found in region ' + aws_region_name)
+        print('Please create an EC2 subnetpair before continuing')
         sys.exit(1)
 
     return subnetids
@@ -121,7 +126,7 @@ def configure(args):
     else:
         config_file = os.path.expanduser(os.path.join('~', '.cfncluster', 'config'))
 
-    config = ConfigParser.ConfigParser()
+    config = configparser.ConfigParser()
 
     # Check if configuration file exists
     if os.path.isfile(config_file):
@@ -154,9 +159,9 @@ def configure(args):
     for section in sections:
         try:
             config.add_section(section['__name__'])
-        except ConfigParser.DuplicateSectionError:
+        except configparser.DuplicateSectionError:
             pass
-        for key, value in section.iteritems():
+        for key, value in section.items():
             # Only update configuration if not set
             if value is not None and key is not '__name__':
                 config.set(section['__name__'], key, value)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,3 +4,9 @@
 set -x
 echo $PATH
 which cfncluster
+
+# display version number
+cfncluster version
+
+# display help message
+cfncluster --help


### PR DESCRIPTION
This PR adds support for Python 3.

The changes are just minor syntax differences. The more complex parts are related to imports of modules that have been renamed/moved in the standard library.

I also added a very basic test to check the `cfncluster` command runs on Travis. In the longer term it would be nice to add some more tests with some mock interfaces.

I've tested configuring, creating, checking status, stopping, starting and deleting a cluster on both Python 2 and 3 with these changes. Tested on OS X with Anaconda Python.

Closes #157.