### PR TITLE
Small fixes to improve HTTP config sanity check error messages.

### DIFF
--- a/cli/cfncluster/config_sanity.py
+++ b/cli/cfncluster/config_sanity.py
@@ -97,10 +97,10 @@ def check_resource(region, aws_access_key_id, aws_secret_access_key, resource_ty
             try:
                 urllib.request.urlopen(resource_value)
             except urllib.error.HTTPError as e:
-                print(e.code)
+                print('Config sanity error:', resource_value, e.code, e.reason)
                 sys.exit(1)
             except urllib.error.URLError as e:
-                print(e.args)
+                print('Config sanity error:', resource_value, e.reason)
                 sys.exit(1)
     # EC2 EBS Snapshot Id
     elif resource_type == 'EC2Snapshot':


### PR DESCRIPTION
Updates the error message when config_sanity.py is checking URL based resources i.e. the source of the 403 message.

**Before:**
$ cfncluster create foo
Starting: foo
403

**After:**
$ cfncluster create foo
Starting: foo
Config sanity error: https://s3.amazonaws.com/dougalb/cfncluster/cfncluster.cfn.yaml2 403 Forbidden
