### PR TITLE
Fix Python 3 build failures with correct usage of except

### DIFF
--- a/cli/cfncluster/cfncluster.py
+++ b/cli/cfncluster/cfncluster.py
@@ -53,7 +53,7 @@ def create(args):
             vpcconn = boto.vpc.connect_to_region(config.region,aws_access_key_id=config.aws_access_key_id,
                                                  aws_secret_access_key=config.aws_secret_access_key)
             availability_zone = str(vpcconn.get_all_subnets(subnet_ids=master_subnet_id)[0].availability_zone)
-        except Exception, e:
+        except Exception as e:
             logger.critical(e.message)
             sys.exit(1)
         config.parameters.append(('AvailabilityZone', availability_zone))
@@ -66,7 +66,7 @@ def create(args):
     try: 
         cfnconn = boto.cloudformation.connect_to_region(config.region,aws_access_key_id=config.aws_access_key_id,
                                                         aws_secret_access_key=config.aws_secret_access_key)
-    except Exception, e:
+    except Exception as e:
         logger.critical(e.message)
         sys.exit(1)
 
@@ -100,7 +100,7 @@ def create(args):
     except KeyboardInterrupt:
         print('\nExiting...')
         sys.exit(0)
-    except Exception, e:
+    except Exception as e:
         logger.critical(e.message)
         sys.exit(1)
 


### PR DESCRIPTION
While Python 2 accepts both the old and the new syntax, Python 3 builds choke on
this as an error. This should fix the Travis Python 3 builds.