### PR TITLE
Add a new CLI option to stop only the ComputeFleet.

### DIFF
--- a/cli/cfncluster/cfncluster.py
+++ b/cli/cfncluster/cfncluster.py
@@ -214,6 +214,10 @@ def stop(args):
     asg = get_asg(stack_name=stack_name, config=config)
     set_asg_limits(asg=asg, min=0, max=0, desired=0)
 
+    # Skip the Master shutdown if requested by the user
+    if args.compute_only:
+        return
+
     # Stop master Server
     master_server_id = get_master_server_id(stack_name, config)
     ec2conn = boto.ec2.connect_to_region(config.region,aws_access_key_id=config.aws_access_key_id,

--- a/cli/cfncluster/cli.py
+++ b/cli/cfncluster/cli.py
@@ -116,6 +116,8 @@ def main():
     pstop = subparsers.add_parser('stop', help='stop a cluster that has been created')
     pstop.add_argument("cluster_name", type=str, default=None,
                         help='stop a cfncluster with the provided name.')
+    pstop.add_argument("--compute-only", "-c", action='store_true', dest="compute_only", default=False,
+                        help='Stop the ComputeFleet, but leave the MasterServer running for debugging/development.')
     pstop.set_defaults(func=stop)
 
     pstatus = subparsers.add_parser('status', help='pull the current status of the cluster')

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -67,15 +67,24 @@ optional arguments:
 stop
 ====
 
-This first sets the Auto Scaling Group parameters to :code:`min/max/desired = 0/0/0` then stops the Master Server. This polls on the status of the master server until it is stopped. 
+This first sets the Auto Scaling Group parameters to :code:`min/max/desired =
+0/0/0` then stops the Master Server. This polls on the status of the master
+server until it is stopped. If desired, one can optionally use the
+:code:`--compute-only argument` to leave the Master Server intact.
 
-.. note:: A stopped cluster won't charge for EC2 usage but will still charge for EBS usage and Elastic IP addresses. Each time you bring up an instance it charges you for an hour so bringing it up and down multiple times within an hour isn't reccomended. For more info see `Stop and Start Your Instance <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Stop_Start.html>`_.
+.. note:: A stopped cluster won't charge for EC2 usage but will still charge for
+   EBS usage and Elastic IP addresses. Each time you bring up an instance it
+charges you for an hour so bringing it up and down multiple times within an hour
+isn't reccomended. For more info see `Stop and Start Your Instance
+<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Stop_Start.html>`_.
 
 positional arguments:
   cluster_name  stop a cfncluster with the provided name.
 
 optional arguments:
   -h, --help    show this help message and exit
+  --compute-only, -c  Stop the ComputeFleet, but leave the MasterServer
+                      running for debugging/development
 
 ::
 


### PR DESCRIPTION
This commit adds a new option, --compute-only/-c, to stop a cluster while
leaving the MasterServer intact. This would come in handy when a user wants to
use the MasterServer for compilation, development, or when debugging core files
and such.

```
usage: cfncluster stop [-h] [--compute-only] cluster_name

positional arguments:
  cluster_name        stop a cfncluster with the provided name.

optional arguments:
  -h, --help          show this help message and exit
  --compute-only, -c  Stop the ComputeFleet, but leave the MasterServer
                      running for debugging/development.
```