### PR TITLE
Fix for extra paramater passing in cli

### DIFF
--- a/cli/cfncluster/cfnconfig.py
+++ b/cli/cfncluster/cfnconfig.py
@@ -321,8 +321,8 @@ class CfnClusterConfig(object):
         # Handle extra parameters supplied on command-line
         try:
             if self.args.extra_parameters is not None:
-                self.parameters = dict(self.parameters)
-                self.__temp_dict = dict(list(self.parameters.items()) + list(self.args.extra_parameters.items()))
+                self.__temp_dict = dict(self.parameters)
+                self.__temp_dict.append(dict(self.args.extra_parameters))
                 self.__dictlist = []
                 for key, value in self.__temp_dict.items():
                     temp = [str(key),str(value)]


### PR DESCRIPTION
Fix based upon this forum discussion:
https://forums.aws.amazon.com/thread.jspa?threadID=261254
Tested locally to confirm -p option is no longer causing create to error out