### PR TITLE
Fix: G2.8xLarge does not support EBS-optimized launch

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -1610,7 +1610,7 @@
       },
       "g2.8xlarge" : {
         "Arch" : "64HVM",
-        "EBSOpt" : "True"
+        "EBSOpt" : "False"
       },
       "p2.xlarge" : {
         "Arch" : "64HVM",

--- a/cloudformation/cfncluster.cfn.yaml
+++ b/cloudformation/cfncluster.cfn.yaml
@@ -1004,7 +1004,7 @@ Mappings:
       EBSOpt: 'True'
     g2.8xlarge:
       Arch: 64HVM
-      EBSOpt: 'True'
+      EBSOpt: 'False'
     p2.xlarge:
       Arch: 64HVM
       EBSOpt: 'True'


### PR DESCRIPTION
cfncluster create fails if the instance is g2.8xlarge because
of EBS-optimized launch is not supported in this type

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>