### PR TITLE
Upgrading dependencies to latest version

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -21,7 +21,7 @@ def read(fname):
 
 console_scripts = ['cfncluster = cfncluster.cli:main']
 version = "1.3.3"
-requires = ['boto>=2.42.0', 'awscli>=1.10.56', 'future>=0.16.0'] 
+requires = ['boto>=2.48.0', 'awscli>=1.11.175', 'future>=0.16.0']
 
 if sys.version_info[:2] == (2, 6):
     # For python2.6 we have to require argparse since it


### PR DESCRIPTION
Fixes #233 when passing s3:// in template_url eventhough
we skip validation, cloudformation cli doesn't support taking
s3 url properly which was fixed in aws/aws-cli#2331 hence
justifies upgrading aws-cli. We also upgrade all other
dependencies to latest version as of today.

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>


===== Testing =====
python setup.py test
running test
Searching for awscli>=1.11.175
Best match: awscli 1.11.175
Processing awscli-1.11.175-py2.7.egg

Using /rhel5pdi/workplace/mohgan/open-source/cfncluster/cli/.eggs/awscli-1.11.175-py2.7.egg
running egg_info
writing requirements to cfncluster.egg-info/requires.txt
writing cfncluster.egg-info/PKG-INFO
writing top-level names to cfncluster.egg-info/top_level.txt
writing dependency_links to cfncluster.egg-info/dependency_links.txt
writing entry points to cfncluster.egg-info/entry_points.txt
reading manifest file 'cfncluster.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching '*' under directory 'cfncluster/cloudformation'
writing manifest file 'cfncluster.egg-info/SOURCES.txt'
running build_ext

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK