### PR TITLE
Increasing sqs queue message retention period

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -1821,7 +1821,9 @@
   "Resources" : {
     "SQS" : {
       "Type" : "AWS::SQS::Queue",
-      "Properties" : {},
+      "Properties" : {
+        "MessageRetentionPeriod": 1209600
+      },
       "Metadata" : {
         "AWS::CloudFormation::Designer" : {
           "id" : "2f599618-92e8-49cf-92bd-551ba9775f39"

--- a/cloudformation/cfncluster.cfn.yaml
+++ b/cloudformation/cfncluster.cfn.yaml
@@ -1072,7 +1072,8 @@ Mappings:
 Resources:
   SQS:
     Type: AWS::SQS::Queue
-    Properties: {}
+    Properties:
+      MessageRetentionPeriod: 1209600
     Metadata:
       AWS::CloudFormation::Designer:
         id: 2f599618-92e8-49cf-92bd-551ba9775f39


### PR DESCRIPTION
As of today we have default retenion period
for sqs message (which is 4 days), stop/start behavior
may miss some message as we stop master instance today.
Increasing sqs message retention period to max (14 days)
to minimize the chance of this occurence.

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>