### PR TITLE
Remove Known Issues blurb about C5 support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,13 +13,6 @@ many different types of clustered applications and can easily be
 extended to support different frameworks. The CLI is stateless,
 everything is done using CloudFormation or resources within AWS.
 
-Known Issues
-============
-
-* CfnCluster 1.4.0 supports the C5 instance family.  However, the
-  CentOS 6 and CentOS 7 AMIs included with CfnCluster do not support
-  C5.
-
 Documentation
 =============
 


### PR DESCRIPTION
With the latest round of AMI updates, we no longer have this issue. Both
versions of CentOS now support C5.

Signed-off-by: Raghu Raja <craghun@amazon.com>