### PR TITLE
Rolling back cookbook version to 1.4.0

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -1761,7 +1761,7 @@
     "CfnClusterVersions" : {
       "default" : {
         "cfncluster" : "cfncluster-1.4.1",
-        "cookbook" : "cfncluster-cookbook-1.4.1",
+        "cookbook" : "cfncluster-cookbook-1.4.0",
         "chef" : "12.19.36",
         "ridley" : "5.1.0",
         "berkshelf" : "5.6.4",

--- a/cloudformation/cfncluster.cfn.yaml
+++ b/cloudformation/cfncluster.cfn.yaml
@@ -981,7 +981,7 @@ Mappings:
   CfnClusterVersions:
     default:
       cfncluster: cfncluster-1.4.1
-      cookbook: cfncluster-cookbook-1.4.1
+      cookbook: cfncluster-cookbook-1.4.0
       chef: 12.19.36
       ridley: 5.1.0
       berkshelf: 5.6.4


### PR DESCRIPTION
As we plan do minor release of cfncluster, and
we haven't changed anything in cookbook, I recommend
sticking to cookbook version 1.4.0 (we bump to 1.4.1
as post-release activity)

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>