### PR TITLE
test: Add test to launch and test clusters

### DIFF
--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -1,0 +1,234 @@
+#!/usr/bin/python
+#
+# Copyright 2018      Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy
+# of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+#
+# Build a cluster for each combination of region, base_os, and
+# scheduler, and run a test script on each cluster.  To avoid bouncing
+# against limits in each region, the number of simultaneously built
+# clusters in each region is a configuration parameter.
+#
+# NOTE: To simplify this script, at least one subnet in every region
+# to be tested must have a resource tag named "CfnClusterTestSubnet"
+# (value does not matter).  That subnet will be used as the launch
+# target for the cluster.
+
+import os
+import sys
+import subprocess
+import threading
+import re
+import argparse
+import Queue
+import boto3
+
+#
+# configuration
+#
+username_map = { 'alinux' : 'ec2-user',
+                 'centos6' : 'centos',
+                 'centos7' : 'centos',
+                 'ubuntu1404' : 'ubuntu',
+                 'ubuntu1604' : 'ubuntu' }
+
+#
+# global variables (sigh)
+#
+setup = {}
+
+results_lock = threading.Lock()
+failure = 0
+success = 0
+
+
+#
+# run a single test, possibly in parallel
+#
+def run_test(region, distro, scheduler):
+    testname = '%s-%s-%s' % (region, distro, scheduler)
+    test_filename = "config-%s.cfg" % (testname)
+
+    sys.stdout.write("--> %s: Starting\n" % (testname))
+
+    file = open(test_filename, "w")
+    file.write("[aws]\n")
+    file.write("aws_region_name = %s\n" % region)
+    file.write("[cluster default]\n")
+    file.write("vpc_settings = public\n")
+    file.write("key_name = default\n")
+    file.write("base_os = %s\n" % distro)
+    file.write("master_instance_type = c4.xlarge\n")
+    file.write("compute_instance_type = c4.xlarge\n")
+    file.write("initial_queue_size = 2\n")
+    file.write("maintain_initial_size = true\n")
+    file.write("scheduler = %s\n" % (scheduler))
+    file.write("scaling_settings = custom\n")
+    file.write("[vpc public]\n")
+    file.write("master_subnet_id = %s\n" % (setup[region]['subnet']))
+    file.write("vpc_id = %s\n" % (setup[region]['vpc']))
+    file.write("[global]\n")
+    file.write("cluster_template = default\n")
+    file.write("[scaling custom]\n")
+    file.write("scaling_adjustment = 2\n")
+    file.close()
+
+    stdout_f = open('stdout-%s.txt' % (testname), 'w')
+    stderr_f = open('stderr-%s.txt' % (testname), 'w')
+
+    master_ip = ''
+    username = username_map[distro]
+
+    try:
+        # buld the cluster
+        subprocess.check_call(['cfncluster', '--config', test_filename,
+                               'create', testname],
+                              stdout=stdout_f, stderr=stderr_f)
+
+        # get the master ip, which means grepping through cfncluster status gorp
+        dump = subprocess.check_output(['cfncluster', 'status', testname], stderr=stderr_f)
+        dump_array = dump.splitlines()
+        for line in dump_array:
+             m = re.search('MasterPublicIP"="(.+?)"', line)
+             if m:
+                 master_ip = m.group(1)
+        if master_ip == '':
+             print('!! %s: Master IP not found; aborting !!' % (testname))
+             raise Exception('Master IP not found')
+        print("--> %s master ip: %s" % (testname, master_ip))
+
+        # run test on the cluster...
+        subprocess.check_call(['scp', 'cluster-check.sh', '%s@%s:.' % (username, master_ip)],
+                              stdout=stdout_f, stderr=stderr_f)
+        subprocess.check_call(['ssh', '%s@%s' % (username, master_ip),
+                               '/bin/bash cluster-check.sh %s' % (scheduler)],
+                              stdout=stdout_f, stderr=stderr_f)
+    except Exception as e:
+        sys.stdout.write("!! FAILURE: %s!!\n" % (testname))
+        raise e
+
+    finally:
+        # clean up the cluster
+        subprocess.call(['cfncluster', '--config', test_filename, 'delete', testname],
+                        stdout=stdout_f, stderr=stderr_f)
+        stdout_f.close()
+        stderr_f.close()
+        os.remove(test_filename)
+
+
+#
+# worker thread, there will be config['parallelism'] of these running
+# per region, dispatching work from the work queue
+#
+def test_runner(region, q):
+    global success
+    global failure
+    global results_lock
+
+    retval = 0
+
+    while True:
+        item = q.get()
+
+        # just in case we miss an exception in run_test, don't abort everything...
+        try:
+            retval = run_test(region=region, distro=item['distro'], scheduler=item['scheduler'])
+        except Exception as e:
+            print("Unexpected exception %s: %s" % (str(type(e)), str((e))))
+            retval = 1
+
+        results_lock.acquire(True)
+        if retval == 0:
+            success += 1
+        else:
+            failure += 1
+        results_lock.release()
+        q.task_done()
+
+
+if __name__ == '__main__':
+    config = { 'parallelism' : 3,
+               'regions' : 'us-east-1,us-east-2,us-west-1,us-west-2,' +
+                           'ca-central-1,eu-west-1,eu-west-2,eu-central-1,' +
+                           'ap-southeast-1,ap-southeast-2,ap-northeast-1' +
+                           'ap-south-1,sa-east-1,eu-west-3',
+               'distros' : 'alinux,centos6,centos7,ubuntu1404,ubuntu1604',
+               'schedulers' : 'sge,slurm,torque' }
+
+    parser = argparse.ArgumentParser(description = 'Test runner for CfnCluster')
+    parser.add_argument('--parallelism', help = 'Number of tests per region to run in parallel',
+                        type = int, default = 3)
+    parser.add_argument('--regions', help = 'Comma separated list of regions to test',
+                        type = str)
+    parser.add_argument('--distros', help = 'Comma separated list of distributions to test',
+                        type = str)
+    parser.add_argument('--schedulers', help = 'Comma separated list of schedulers to test',
+                        type = str)
+
+    for key, value in vars(parser.parse_args()).iteritems():
+        if not value == None:
+            config[key] = value
+
+    region_list = config['regions'].split(',')
+    distro_list = config['distros'].split(',')
+    scheduler_list = config['schedulers'].split(',')
+
+    print("==> Regions: %s" % (', '.join(region_list)))
+    print("==> Distros: %s" % (', '.join(distro_list)))
+    print("==> Schedulers: %s" % (', '.join(scheduler_list)))
+    print("==> Parallelism: %d" % (config['parallelism']))
+
+    # Populate subnet / vpc data for all regions we're going to test.
+    for region in region_list:
+        client = boto3.client('ec2', region_name=region)
+        response = client.describe_tags(Filters=[{'Name': 'key',
+                                                  'Values': [ 'CfnClusterTestSubnet' ]}],
+                                        MaxResults=16)
+        if len(response['Tags']) == 0:
+            print('Could not find subnet in %s with CfnClusterTestSubnet tag.  Aborting.' %
+                  (region))
+            exit(1)
+        subnetid = response['Tags'][0]['ResourceId']
+
+        response = client.describe_subnets(SubnetIds = [ subnetid ])
+        if len(response) == 0:
+            print('Could not find subnet info for %s' % (subnetid))
+            exit(1)
+        vpcid = response['Subnets'][0]['VpcId']
+
+        setup[region] = { 'vpc' : vpcid, 'subnet' : subnetid }
+
+
+    work_queues = {}
+    # build up a per-region list of work to do
+    for region in region_list:
+        work_queues[region] = Queue.Queue()
+        for distro in distro_list:
+            for scheduler in scheduler_list:
+                work_item = { 'distro' : distro, 'scheduler' : scheduler }
+                work_queues[region].put(work_item)
+
+    # start all the workers
+    for region in region_list:
+        for i in range(0, config['parallelism']):
+            t = threading.Thread(target = test_runner, args=(region, work_queues[region]))
+            t.daemon = True
+            t.start()
+
+    # wait for all the work queues to be completed in each region
+    for region in region_list:
+        work_queues[region].join()
+
+    # print status...
+    print("==> Success: %d" % (success))
+    print("==> Failure: %d" % (failure))

--- a/tests/cluster-check.sh
+++ b/tests/cluster-check.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# Copyright 2018      Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy
+# of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+#
+# Script executed on clusters from cfncluster-release-check.py.  This
+# script attempts to submit two jobs which must complete in 30
+# minutes, one of which (hopefully) requires scaling (note that
+# scaling is currently not tested on Torque, because it's too big of a
+# pain to determine how many slots per node are on a Torque compute
+# node from the master node).
+#
+
+# in case the scheduler goes nuts, wrap ourselves in a timeout so
+# there's a bounded completion time
+if test "$CHECK_CLUSTER_SUBPROCESS" = ""; then
+   export CHECK_CLUSTER_SUBPROCESS=1
+   timeout -s KILL 30m /bin/bash ./cluster-check.sh "$@"
+   exit $?
+fi
+
+scheduler="$1"
+
+echo "--> scheduler: $scheduler"
+
+set -e
+
+# we submit 2 2-node jobs, each of which are a sleep for 16 minutes.
+# The whole thing has to run in 30 minutes, or the kill above will
+# fail the job, which means that the jobs must run at the same time.
+# The initial cluster is 2 nodes, so we'll need to scale up 2 nodes in
+# less than 10 minutes in order for the test to succeed.
+
+if test "$scheduler" = "slurm" ; then
+    cat > job1.sh <<EOF
+#!/bin/bash
+srun sleep 960
+touch job1.done
+EOF
+    cat > job2.sh <<EOF
+#!/bin/bash
+srun sleep 960
+touch job2.done
+EOF
+
+    chmod +x job1.sh job2.sh
+    rm -f job1.done job2.done
+
+    sbatch -N 2 ./job1.sh
+    sbatch -N 2 ./job2.sh
+
+elif test "$scheduler" = "sge" ; then
+    # get the slots per node count of the first real node (one with a
+    # architecture type of lx-?), so that we can reserve an enitre
+    # node's worth of slots at a time.
+    ppn=` qhost | grep 'lx-' | head -n 1 | sed -n -e 's/[^[:space:]]*[[:space:]]\+[^[:space:]]*[[:space:]]\+\([0-9]\+\).*/\1/p'`
+    count=$((ppn * 2))
+
+    cat > job1.sh <<EOF
+#!/bin/bash
+#$ -pe mpi $count
+#$ -R y
+
+sleep 960
+touch job1.done
+EOF
+    cat > job2.sh <<EOF
+#!/bin/bash
+#$ -pe mpi $count
+#$ -R y
+
+sleep 960
+touch job2.done
+EOF
+
+    chmod +x job1.sh job2.sh
+    rm -f job1.done job2.done
+
+    qsub ./job1.sh
+    qsub ./job2.sh
+
+elif test "$scheduler" = "torque" ; then
+    cat > job1.sh <<EOF
+#!/bin/bash
+sleep 1200
+touch job1.done
+EOF
+    cat > job2.sh <<EOF
+#!/bin/bash
+sleep 1200
+touch job2.done
+EOF
+
+    chmod +x job1.sh job2.sh
+    rm -f job1.done job2.done
+
+    qsub -l nodes=2:ppn=2 ./job1.sh
+    qsub -l nodes=2:ppn=2 ./job2.sh
+
+else
+    echo "!! Unknown scheduler $scheduler !!"
+    exit 1
+fi
+
+done=0
+while test $done = 0 ; do
+    if test -f job1.done -a -f job2.done; then
+	done=1
+    else
+	sleep 1
+    fi
+done
+
+exit 0


### PR DESCRIPTION
Add a pre-release verification test that launches the combination
of region, distro, and scheduler of tests.  Each test will
run a "parallel" job (it's sleep, but on two nodes) and cause a
scale up event, verifying that scale-up works.

We limit the number of tests per region to limit how hard we
push on various AWS limits (like instance count, EIPs,
DynamoDB table creation rate, etc.).  This does mean the test
takes many hours to run (likely 5 hours in the average case).

Signed-off-by: Brian Barrett <bbarrett@amazon.com>