### PR TITLE
cli: Fix configure failure on first use

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+1.4.2
+=====
+* bugfix:``cfncluster``: Fix crash when base directory for config file
+  does not exist
+
 1.4.0
 =====
 * change:``cfncluster``: `cfncluster stop` will terminate compute

--- a/cli/cfncluster/easyconfig.py
+++ b/cli/cfncluster/easyconfig.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
-# Copyright 2013-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License'). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -21,6 +21,7 @@ import boto.vpc
 import os
 import logging
 import stat
+import errno
 
 from . import cfnconfig
 
@@ -166,6 +167,14 @@ def configure(args):
             # Only update configuration if not set
             if value is not None and key is not '__name__':
                 config.set(section['__name__'], key, value)
+
+    # ensure that the directory for the config file exists (because
+    # ~/.cfncluster is likely not to exist on first usage)
+    try:
+        os.makedirs(os.path.dirname(config_file))
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise # can safely ignore EEXISTS for this purpose...
 
     # Write configuration to disk
     open(config_file,'a').close()


### PR DESCRIPTION
Commit 54926c4 exposed a bug in "cfncluster configure" which
caused configure to fail if the base directory for the config
file didn't exit (in the default case, ~/.cfncluster/).  This
wasn't a common problem prior to 54926c4, because logging was
saved to ~/.cfncluster/, and it *did* create the directory
properly.  So create the directory for the config file basename
and avoid the issue, regardless of logging behavior.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>