### PR TITLE
dist: Add changelog for 1.4.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ CHANGELOG
   cfncluster invocation, re-enabled logging in
   ~/.cfncluster/cfncluster-cli.log
 
+1.4.1
+=====
+* bugfix:``cfncluster``: Fix abort due to undefinied logger
 
 1.4.0
 =====


### PR DESCRIPTION
We forgot to add a changelog entry for the 1.4.1
release, so add one after the fact.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>