### PR TITLE
cli: output logging to stdout

### DIFF
--- a/cli/cfncluster/cli.py
+++ b/cli/cfncluster/cli.py
@@ -56,7 +56,7 @@ def config_logger():
     logger = logging.getLogger('cfncluster.cfncluster')
     logger.setLevel(logging.DEBUG)
 
-    ch = logging.StreamHandler()
+    ch = logging.StreamHandler(sys.stdout)
     ch.setLevel(logging.INFO)
     ch.setFormatter(logging.Formatter('%(message)s'))
     logger.addHandler(ch)


### PR DESCRIPTION
Previous output all was sent to stdout, and scripts may rely on
that, so redirect console logging to stdout instead of stderr.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>