### PR TITLE
dist: Add note that old releases are broken

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,3 +27,12 @@ Issues
 Please open a GitHub issue for any feedback or issues:
 https://github.com/awslabs/cfncluster.  There is also an active AWS
 HPC forum which may be helpful:https://forums.aws.amazon.com/forum.jspa?forumID=192.
+
+CfnCluster 1.2 and Earlier
+==========================
+
+For various security (on our side) and maintenance reasons, CfnCluster
+1.2 and earlier have been deprecated.  AWS-side resources necessary to
+create a cluster with CfnCluster 1.2 or earlier are no longer
+available.  Existing clusters will continue to operate, but new
+clusters can not be created.


### PR DESCRIPTION
CfnCluster 1.2 and earlier stored CloudFormation templates
and the cfncluster-cookbook bundle in an S3 bucket that
was not part of the CfnCluster team account.  That bucket
is no longer publicly available, so those releases aren't
so useful for building clusters.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
