### PR TITLE
Complete CloudFormation templates transition to accept longer format IDs

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -731,7 +731,7 @@
       "Description" : "ID of the Subnet you want to provision the Compute Servers into",
       "Type" : "String",
       "Default" : "NONE",
-      "AllowedPattern" : "(NONE|^subnet-[0-9a-z]{8}$)"
+      "AllowedPattern" : "(NONE|^subnet-[0-9a-z]{8}$|^subnet-[0-9a-z]{17}$)"
     },
     "ScalingThreshold" : {
       "Description" : "Threshold for triggering CloudWatch ScaleUp action",
@@ -984,7 +984,7 @@
       "Description" : "Additional VPC secuirty group to be added to instances. Defaults to NONE",
       "Type" : "String",
       "Default" : "NONE",
-      "AllowedPattern" : "(NONE|^sg-[0-9a-z]{8}$)"
+      "AllowedPattern" : "(NONE|^sg-[0-9a-z]{8}$|^sg-[0-9a-z]{17}$)"
     },
     "CWLRegion" : {
       "Description" : "CloudWatch Logs region",
@@ -1056,7 +1056,7 @@
       "Description" : "Existing VPC security group Id",
       "Type" : "String",
       "Default" : "NONE",
-      "AllowedPattern" : "(NONE|^sg-[0-9a-z]{8}$)"
+      "AllowedPattern" : "(NONE|^sg-[0-9a-z]{8}$|^sg-[0-9a-z]{17}$)"
     },
     "EBSVolumeId" : {
       "Description" : "Existing EBS volume Id",

--- a/cloudformation/cfncluster.cfn.yaml
+++ b/cloudformation/cfncluster.cfn.yaml
@@ -529,7 +529,7 @@ Parameters:
     Description: ID of the Subnet you want to provision the Compute Servers into
     Type: String
     Default: NONE
-    AllowedPattern: (NONE|^subnet-[0-9a-z]{8}$)
+    AllowedPattern: (NONE|^subnet-[0-9a-z]{8}$|^subnet-[0-9a-z]{17}$)
   ScalingThreshold:
     Description: Threshold for triggering CloudWatch ScaleUp action
     Type: String
@@ -752,7 +752,7 @@ Parameters:
       to NONE
     Type: String
     Default: NONE
-    AllowedPattern: (NONE|^sg-[0-9a-z]{8}$)
+    AllowedPattern: (NONE|^sg-[0-9a-z]{8}$|^sg-[0-9a-z]{17}$)
   CWLRegion:
     Description: CloudWatch Logs region
     Type: String
@@ -814,7 +814,7 @@ Parameters:
     Description: Existing VPC security group Id
     Type: String
     Default: NONE
-    AllowedPattern: (NONE|^sg-[0-9a-z]{8}$)
+    AllowedPattern: (NONE|^sg-[0-9a-z]{8}$|^sg-[0-9a-z]{17}$)
   EBSVolumeId:
     Description: Existing EBS volume Id
     Type: String


### PR DESCRIPTION
Previously the templates were amended to recognize the longer ID formats for other services (such as AMI and EBS volumes), but the changes didn't extend to subnets and security groups which can also have the long-format IDs. This completes the job.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
