### PR TITLE
CfnCluster Login

### DIFF
--- a/cli/cfncluster/cfncluster.py
+++ b/cli/cfncluster/cfncluster.py
@@ -10,12 +10,12 @@ from __future__ import absolute_import
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-
 from builtins import str
 import sys
 import time
 import logging
 import boto3
+import os
 from botocore.exceptions import ClientError
 
 from . import cfnconfig
@@ -277,6 +277,31 @@ def poll_master_server_state(stack_name, config):
 
     return state
 
+def get_master_server_ip(stack_name, config):
+    ec2 = boto3.client('ec2', region_name=config.region,
+                       aws_access_key_id=config.aws_access_key_id,
+                       aws_secret_access_key=config.aws_secret_access_key)
+
+    master_id = get_master_server_id(stack_name, config)
+
+    try:
+        instance = ec2.describe_instances(InstanceIds=[master_id]) \
+            .get('Reservations')[0] \
+            .get('Instances')[0]
+        ip_address = instance.get('PublicIpAddress')
+        state = instance.get('State').get('Name')
+        if state != 'running' or ip_address is None:
+            logger.info("MasterServer: %s\nCannot get ip address." % state.upper)
+            sys.exit(1)
+        return ip_address
+    except ClientError as e:
+        logger.critical(e.response.get('Error').get('Message'))
+        sys.stdout.flush()
+        sys.exit(1)
+    except KeyboardInterrupt:
+        logger.info('\nExiting...')
+        sys.exit(0)
+
 def get_ec2_instances(stack, config):
     cfn = boto3.client('cloudformation', region_name=config.region,
                        aws_access_key_id=config.aws_access_key_id,
@@ -345,6 +370,56 @@ def instances(args):
 
     for instance in instances:
         print('%s         %s' % (instance[0],instance[1]))
+
+def get_head_user(parameters, template):
+    mappings = template.get("TemplateBody") \
+            .get("Mappings") \
+            .get("OSFeatures")
+    base_os =[i.get('ParameterValue') for i in parameters if i.get('ParameterKey') == "BaseOS"][0]
+    return mappings.get(base_os).get("User")
+
+def command(args, extra_args):
+    stack = ('cfncluster-' + args.cluster_name)
+    config = cfnconfig.CfnClusterConfig(args)
+    if args.command in config.aliases:
+        config_command = config.aliases[args.command]
+    else:
+        config_command = "ssh {CFN_USER}@{MASTER_IP} {ARGS}"
+
+    cfn = boto3.client('cloudformation', region_name=config.region,
+                       aws_access_key_id=config.aws_access_key_id,
+                       aws_secret_access_key=config.aws_secret_access_key)
+    try:
+        status = cfn.describe_stacks(StackName=stack).get("Stacks")[0].get('StackStatus')
+        invalid_status = ['DELETE_COMPLETE', 'DELETE_IN_PROGRESS']
+        if status in invalid_status:
+            logger.info("Stack status: %s. Cannot SSH while in %s" % (status, ' or '.join(invalid_status)))
+            sys.exit(1)
+        ip = get_master_server_ip(stack, config)
+        stack_result = cfn.describe_stacks(StackName=stack).get('Stacks')[0]
+        template = cfn.get_template(StackName=stack)
+        username = get_head_user(stack_result.get('Parameters'), template)
+
+        try:
+            from shlex import quote as cmd_quote
+        except ImportError:
+            from pipes import quote as cmd_quote
+
+        # build command
+        cmd = config_command.format(CFN_USER=username, MASTER_IP=ip, ARGS=' '.join(cmd_quote(str(e)) for e in extra_args))
+
+        # run command
+        if not args.dryrun:
+            os.system(cmd)
+        else:
+            logger.info(cmd)
+    except ClientError as e:
+            logger.critical(e.response.get('Error').get('Message'))
+            sys.stdout.flush()
+            sys.exit(1)
+    except KeyboardInterrupt:
+        logger.info('\nExiting...')
+        sys.exit(0)
 
 def status(args):
     stack = ('cfncluster-' + args.cluster_name)
@@ -439,4 +514,3 @@ def delete(args):
     except KeyboardInterrupt:
         logger.info('\nExiting...')
         sys.exit(0)
-

--- a/cli/cfncluster/cfnconfig.py
+++ b/cli/cfncluster/cfnconfig.py
@@ -338,6 +338,13 @@ class CfnClusterConfig(object):
         except AttributeError:
             pass
 
+        # handle aliases
+        self.aliases = {}
+        self.__alias_section = 'aliases'
+        if __config.has_section(self.__alias_section):
+            for alias in __config.options(self.__alias_section):
+                self.aliases[alias] = __config.get(self.__alias_section, alias)
+
         # Handle extra parameters supplied on command-line
         try:
             if self.args.extra_parameters is not None:

--- a/cli/cfncluster/easyconfig.py
+++ b/cli/cfncluster/easyconfig.py
@@ -141,10 +141,11 @@ def configure(args):
     # Dictionary of values we want to set
     s_global = { '__name__': 'global', 'cluster_template': cluster_template, 'update_check': 'true', 'sanity_check': 'true' }
     s_aws = { '__name__': 'aws', 'aws_access_key_id': aws_access_key_id, 'aws_secret_access_key': aws_secret_access_key, 'aws_region_name': aws_region_name }
+    s_aliases = {'__name__': 'aliases', 'ssh': 'ssh {CFN_USER}@{MASTER_IP} {ARGS}'}
     s_cluster = { '__name__': 'cluster ' + cluster_template, 'key_name': key_name, 'vpc_settings': vpcname }
     s_vpc = { '__name__': 'vpc ' + vpcname, 'vpc_id': vpc_id, 'master_subnet_id': master_subnet_id }
 
-    sections = [s_aws, s_cluster, s_vpc, s_global]
+    sections = [s_aws, s_cluster, s_vpc, s_global, s_aliases]
 
     # Loop through the configuration sections we care about
     for section in sections:

--- a/cli/cfncluster/examples/config
+++ b/cli/cfncluster/examples/config
@@ -19,6 +19,11 @@ sanity_check = true
 # (Defaults to us-east-1 if not defined in enviornment or below)
 #aws_region_name = #region
 
+[aliases]
+# This is the aliases section, you can configure
+# ssh alias here
+ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
+
 ## cfncluster templates
 [cluster default]
 # Name of an existing EC2 KeyPair to enable SSH access to the instances.

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -147,6 +147,39 @@ optional arguments:
 
     $ cfncluster delete mycluster
 
+ssh
+====
+
+Runs ssh to the master node, with username and ip filled in based on the provided cluster.
+
+For example:
+    cfncluster ssh mycluster -i ~/.ssh/id_rsa
+
+Results in an ssh command with username and ip address pre-filled.
+
+    ssh ec2-user@1.1.1.1 -i ~/.ssh/id_rsa
+
+SSH command is defined in the global config file, under the aliases section and can be customized:
+
+    [aliases]
+    ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
+
+Variables substituted:
+    {CFN_USER}
+    {MASTER_IP}
+    {ARGS} (only if specified on the cli)
+
+positional arguments:
+  cluster_name  name of the cluster to set variables for.
+
+optional arguments:
+  -h, --help    show this help message and exit
+  --dryrun, -d  print command and exit.
+
+::
+
+    $cfncluster ssh mycluster -i ~/.ssh/id_rsa -v
+
 status
 ======
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -61,6 +61,20 @@ If not defined, boto will attempt to use a) environment or b) EC2 IAM role. ::
     # Defaults to us-east-1 if not defined in environment or below
     aws_region_name = #region
 
+
+aliases
+^^^^^^^
+This is the aliases section. Use this section to customize the `ssh` command.
+
+`CFN_USER` is set to the default username for the os.
+`MASTER_IP` is set to the ip address of the master instance.
+`ARGS` is set to whatever arguments the user provides after `cfncluster ssh cluster_name`. ::
+
+    [aliases]
+    # This is the aliases section, you can configure
+    # ssh alias here
+    ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
+
 .. _cluster_definition:
 
 cluster


### PR DESCRIPTION
## Overview
Add cli command `cfncluster ssh mycluster` , this is defined in the `aliases` portion of the config file:

```
[aliases]
ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
```

Before execution, the username and ip address are substituted in as well as any provided arguments.

For example:

```
cfncluster ssh mycluster -i ~/.ssh/id_rsa -v
```

Executes as (with username assumed to be `ec2-user` and ip address as `1.1.1.1`):

```
ssh ec2-user@1.1.1.1 -i ~/.ssh/id_rsa -v
```