### PR TITLE
Strip leading and trailing spaces from user's inputs

### DIFF
--- a/cli/cfncluster/easyconfig.py
+++ b/cli/cfncluster/easyconfig.py
@@ -47,7 +47,7 @@ def prompt(prompt, default_value=None, hidden=False, options=None):
     if var == '':
         return default_value
     else:
-        return var
+        return var.strip()
 
 def get_regions():
     regions = boto.ec2.regions()


### PR DESCRIPTION
*Issue:* If the user's input for the `cfncluster configure` command (e.g. VPC ID) contains trailing or leading spaces the next query for subnets fails with the message: _"No subnets found in region ..."_

*Description of changes:* The user input is sanitized removing both trailing and leading spaces and this makes the queries work in any case.