### PR TITLE
Change scale up threshold to 10

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -941,7 +941,7 @@
     "ScalingThreshold2" : {
       "Description" : "Threshold for triggering CloudWatch ScaleUp2 action",
       "Type" : "String",
-      "Default" : "200"
+      "Default" : "10"
     },
     "ScalingCooldown" : {
       "Description" : "Period in seconds to wait before allowing further scaling actions",


### PR DESCRIPTION
## Background
The value was originally set to `200` because it referred to vcpus.
We've changed slurm and torque to look at number of nodes instead of vcpu's so
this value needs to change as well.

* Slurm https://github.com/awslabs/cfncluster-cookbook/pull/99
* Torque https://github.com/awslabs/cfncluster-cookbook/pull/102

Signed-off-by: Sean Smith <seaam@amazon.com>
