### PR TITLE
Add empty line in output for the create and delete commands

### DIFF
--- a/cli/cfncluster/cfncluster.py
+++ b/cli/cfncluster/cfncluster.py
@@ -105,7 +105,7 @@ def create(args):
                         logger.info("  - %s %s %s" %
                                     (event.resource_type, event.logical_resource_id,
                                      event.resource_status_reason))
-
+            logger.info('')
             outputs = cfnconn.describe_stacks(stack)[0].outputs
             for output in outputs:
                 logger.info(output)
@@ -496,7 +496,7 @@ def delete(args):
                 logger.critical(e.message)
                 sys.stdout.flush()
             else:
-                logger.info('Cluster deleted successfully.')
+                logger.info('\nCluster deleted successfully.')
             sys.exit(0)
         else:
             raise e


### PR DESCRIPTION
the output of the create command was showing the first "Output: ..."
info on the same line of the "Status: ..." one

the output of the delete command wasn't showing the statement "Cluster
deleted successfully" on a new line

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
