### PR TITLE
Add EC2 Describe Volumes Permission

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,10 @@ Please open a GitHub issue for any feedback or issues:
 https://github.com/awslabs/cfncluster.  There is also an active AWS
 HPC forum which may be helpful:https://forums.aws.amazon.com/forum.jspa?forumID=192.
 
+CfnCluster 1.5 IAM Change
+=========================
+Between CfnCluster 1.4.2 and 1.5.0 we made a change to the CfnClusterInstancePolicy that adds “ec2:DescribeVolumes” permissions. If you’re using a custom policy (e.g. you specify "ec2_iam_role" in your config) be sure it includes this new permission. See https://cfncluster.readthedocs.io/en/latest/iam.html
+
 CfnCluster 1.2 and Earlier
 ==========================
 

--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -1974,6 +1974,7 @@
             {
               "Sid" : "EC2",
               "Action" : [
+                "ec2:DescribeVolumes",
                 "ec2:AttachVolume",
                 "ec2:DescribeInstanceAttribute",
                 "ec2:DescribeInstanceStatus",

--- a/docs/source/iam.rst
+++ b/docs/source/iam.rst
@@ -3,6 +3,10 @@
 IAM in CfnCluster
 ========================
 
+.. warning::
+    Between CfnCluster 1.4.2 and 1.5.0 we added a change to the `CfnClusterInstancePolicy` that adds "ec2:DescribeVolumes" permissions. If you're using a custom policy (e.g. you specify "ec2_iam_role" in your config) be sure it includes this new permission.
+
+
 CfnCluster utilizes multiple AWS services to deploy and operate a cluster. The services used are listed in the :ref:`AWS Services used in CfnCluster <aws_services>` section of the documentation.
  
 CfnCluster uses EC2 IAM roles to enable instances access to AWS services for the deployment and operation of the cluster. By default the EC2 IAM role is created as part of the cluster creation by CloudFormation. This means that the user creating the cluster must have the appropriate level of permissions
@@ -30,6 +34,7 @@ CfnClusterInstancePolicy
                   "*"
               ],
               "Action": [
+                  "ec2:DescribeVolumes",
                   "ec2:AttachVolume",
                   "ec2:DescribeInstanceAttribute",
                   "ec2:DescribeInstanceStatus",


### PR DESCRIPTION
To fix a bug, we added logic to poll on the status of the EBS volume.
This requires "ec2:DescribeVolumes" permissions in the IAM role.
Since some customers provide their own role, I've added a warning in
the documentation about including the new permission.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
