### PR TITLE
cli: fix variable name in update and get_master_server_id functions

### DIFF
--- a/cli/cfncluster/cfncluster.py
+++ b/cli/cfncluster/cfncluster.py
@@ -136,7 +136,7 @@ def update(args):
             temp_resources.extend(resources)
             if not resources.next_token:
                 break
-            resources = cfnconn.describe_stack_resources(stack, next_token=resources.next_token)
+            resources = cfnconn.describe_stack_resources(stack_name, next_token=resources.next_token)
         resources = temp_resources
         asg = [r for r in resources if r.logical_resource_id == 'ComputeFleet'][0].physical_resource_id
 
@@ -247,7 +247,7 @@ def get_master_server_id(stack_name, config):
         temp_resources.extend(resources)
         if not resources.next_token:
             break
-        resources = cfnconn.describe_stack_resources(stack, next_token=resources.next_token)
+        resources = cfnconn.describe_stack_resources(stack_name, next_token=resources.next_token)
 
     return [r.physical_resource_id for r in resources if r.logical_resource_id == 'MasterServer'][0]
 


### PR DESCRIPTION
The variable previously defined is stack_name and not stack.

Signed-off-by: Enrico Usai <usai@amazon.com>