### PR TITLE
fix 'dict' object has no attribute 'append'

### DIFF
--- a/cli/cfncluster/cfnconfig.py
+++ b/cli/cfncluster/cfnconfig.py
@@ -331,7 +331,7 @@ class CfnClusterConfig(object):
         try:
             if self.args.extra_parameters is not None:
                 self.__temp_dict = dict(self.parameters)
-                self.__temp_dict.append(dict(self.args.extra_parameters))
+                self.__temp_dict.update(dict(self.args.extra_parameters))
                 self.__dictlist = []
                 for key, value in self.__temp_dict.items():
                     temp = [str(key),str(value)]


### PR DESCRIPTION
Dictionary does not have method append

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
