### PR TITLE
add variable to customize cfncluster node package

### DIFF
--- a/cli/cfncluster/cfnconfig.py
+++ b/cli/cfncluster/cfnconfig.py
@@ -223,7 +223,7 @@ class CfnClusterConfig(object):
                                       master_root_volume_size=('MasterRootVolumeSize',None),compute_root_volume_size=('ComputeRootVolumeSize',None),
                                       base_os=('BaseOS',None),ec2_iam_role=('EC2IAMRoleName',None),extra_json=('ExtraJson',None),
                                       custom_chef_cookbook=('CustomChefCookbook',None),custom_chef_runlist=('CustomChefRunList',None),
-                                      additional_cfn_template=('AdditionalCfnTemplate',None)
+                                      additional_cfn_template=('AdditionalCfnTemplate',None),custom_node_package=('CustomNodePackage', None)
                                       )
 
         # Loop over all the cluster options and add define to parameters, raise Exception if defined but null

--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -75,6 +75,7 @@
             "CWLLogGroup",
             "CustomChefRunList",
             "CustomChefCookbook",
+            "CustomNodePackage",
             "ExtraJson",
             "Tenancy",
             "EphemeralKMSKeyId",
@@ -246,6 +247,9 @@
         },
         "CustomChefCookbook" : {
           "default" : "custom_chef_cookbook"
+        },
+        "CustomNodePackage" : {
+          "default" : "custom_node_package"
         },
         "CustomChefRunList" : {
           "default" : "custom_chef_runlist"
@@ -1003,6 +1007,11 @@
     },
     "CustomChefCookbook" : {
       "Description" : "URL of custom cookbook that will override the default. This will be unpacked and then dependencies resolved with Berkshelf.",
+      "Type" : "String",
+      "Default" : "NONE"
+    },
+    "CustomNodePackage" : {
+      "Description" : "URL of custom cfncluster node package that will override the default. This will be unpacked and then installed on the node.",
       "Type" : "String",
       "Default" : "NONE"
     },
@@ -2693,6 +2702,9 @@
                         "SQS",
                         "QueueName"
                       ]
+                    },
+                    "custom_node_package" : {
+                      "Ref" : "CustomNodePackage"
                     }
                   },
                   "run_list" : {
@@ -3392,6 +3404,9 @@
                         },
                         "User"
                       ]
+                    },
+                    "custom_node_package" : {
+                      "Ref" : "CustomNodePackage"
                     }
                   },
                   "run_list" : {

--- a/cloudformation/cfncluster.cfn.yaml
+++ b/cloudformation/cfncluster.cfn.yaml
@@ -59,6 +59,7 @@ Metadata:
           - CWLLogGroup
           - CustomChefRunList
           - CustomChefCookbook
+          - CustomNodePackage
           - ExtraJson
           - Tenancy
           - EphemeralKMSKeyId
@@ -174,6 +175,8 @@ Metadata:
         default: extra_json
       CustomChefCookbook:
         default: custom_chef_cookbook
+      CustomNodePackage:
+        default: custom_node_package
       CustomChefRunList:
         default: custom_chef_runlist
       EBSSnapshotId:
@@ -768,6 +771,11 @@ Parameters:
   CustomChefCookbook:
     Description: URL of custom cookbook that will override the default. This will
       be unpacked and then dependencies resolved with Berkshelf.
+    Type: String
+    Default: NONE
+  CustomNodePackage:
+    Description: URL of custom cfncluster node package that will override the default. This will
+      be unpacked and then installed on the node.
     Type: String
     Default: NONE
   ExtraJson:
@@ -1657,6 +1665,7 @@ Resources:
                   cfn_cluster_user: !FindInMap [OSFeatures, !Ref 'BaseOS', User]
                   cfn_ddb_table: !Ref 'DynamoDBTable'
                   cfn_sqs_queue: !GetAtt 'SQS.QueueName'
+                  custom_node_package: !Ref 'CustomNodePackage'
                 run_list: !If [UseCustomRunList, !Ref 'CustomChefRunList', !Join [
                     '', ['recipe[cfncluster::', !Ref 'Scheduler', '_config]']]]
             /etc/chef/client.rb:
@@ -2174,6 +2183,7 @@ Resources:
                   cfn_master: !GetAtt 'MasterServer.PrivateDnsName'
                   cfn_node_type: ComputeFleet
                   cfn_cluster_user: !FindInMap [OSFeatures, !Ref 'BaseOS', User]
+                  custom_node_package: !Ref 'CustomNodePackage'
                 run_list: !If [UseCustomRunList, !Ref 'CustomChefRunList', !Join [
                     '', ['recipe[cfncluster::', !Ref 'Scheduler', '_config]']]]
             /etc/chef/client.rb:


### PR DESCRIPTION
previously the customization was done setting the variable through the
extra_json variable

this change is related to
https://github.com/awslabs/cfncluster-cookbook/commit/6d59d47efdca24b751f92af6eda17ee3c19f93de

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
