### PR TITLE
Fix and improvements for the cfncluster-release-check script

### DIFF
--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -19,10 +19,12 @@
 # against limits in each region, the number of simultaneously built
 # clusters in each region is a configuration parameter.
 #
-# NOTE: To simplify this script, at least one subnet in every region
-# to be tested must have a resource tag named "CfnClusterTestSubnet"
-# (value does not matter).  That subnet will be used as the launch
-# target for the cluster.
+# NOTE:
+# - This script requires python2
+# - To simplify this script, at least one subnet in every region
+#   to be tested must have a resource tag named "CfnClusterTestSubnet"
+#   (value does not matter). That subnet will be used as the launch
+#   target for the cluster.
 
 import os
 import sys

--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -139,14 +139,13 @@ def test_runner(region, q):
     global failure
     global results_lock
 
-    retval = 0
-
     while True:
         item = q.get()
 
         # just in case we miss an exception in run_test, don't abort everything...
         try:
-            retval = run_test(region=region, distro=item['distro'], scheduler=item['scheduler'])
+            run_test(region=region, distro=item['distro'], scheduler=item['scheduler'])
+            retval = 0
         except Exception as e:
             print("Unexpected exception %s: %s" % (str(type(e)), str((e))))
             retval = 1

--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -110,9 +110,11 @@ def run_test(region, distro, scheduler):
         print("--> %s master ip: %s" % (testname, master_ip))
 
         # run test on the cluster...
-        subprocess.check_call(['scp', 'cluster-check.sh', '%s@%s:.' % (username, master_ip)],
+        subprocess.check_call(['scp', '-o', 'StrictHostKeyChecking=no',
+                               'cluster-check.sh', '%s@%s:.' % (username, master_ip)],
                               stdout=stdout_f, stderr=stderr_f)
-        subprocess.check_call(['ssh', '%s@%s' % (username, master_ip),
+        subprocess.check_call(['ssh', '-o', 'StrictHostKeyChecking=no',
+                               '%s@%s' % (username, master_ip),
                                '/bin/bash cluster-check.sh %s' % (scheduler)],
                               stdout=stdout_f, stderr=stderr_f)
     except Exception as e:

--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -99,12 +99,12 @@ def run_test(region, distro, scheduler):
         dump = subprocess.check_output(['cfncluster', 'status', testname], stderr=stderr_f)
         dump_array = dump.splitlines()
         for line in dump_array:
-             m = re.search('MasterPublicIP"="(.+?)"', line)
-             if m:
-                 master_ip = m.group(1)
+            m = re.search('MasterPublicIP"="(.+?)"', line)
+            if m:
+                master_ip = m.group(1)
         if master_ip == '':
-             print('!! %s: Master IP not found; aborting !!' % (testname))
-             raise Exception('Master IP not found')
+            print('!! %s: Master IP not found; aborting !!' % (testname))
+            raise Exception('Master IP not found')
         print("--> %s master ip: %s" % (testname, master_ip))
 
         # run test on the cluster...


### PR DESCRIPTION
+ Fix indentation and trailing spaces 

+ Add python2 requirement in the introduction notes

+ Add `StrictHostKeyChecking=0` to avoid user confirmation during ssh and scp connections

+  Fix return value check for `cfncluster-release-check` script:
    +  `run_test()` doesn't return a value, so `retval` is None.
    +  _None_ means "no value" so the test `retval == 0` can give erratic behaviour.
    + We are going to ignore the return value of `run_test()`, because there is no one
        and set retval to 0 after the run if no Exception are raised.

+ Add input parameter for Key Pair name 