### PR TITLE
Remove space before semicolon from cfncluster status output

### DIFF
--- a/cli/cfncluster/cfncluster.py
+++ b/cli/cfncluster/cfncluster.py
@@ -104,7 +104,7 @@ def create(args):
             logger.info('')
             outputs = cfn.describe_stacks(StackName=stack_name).get("Stacks")[0].get('Outputs', [])
             for output in outputs:
-                logger.info("%s : %s" % (output.get('OutputKey'), output.get('OutputValue')))
+                logger.info("%s: %s" % (output.get('OutputKey'), output.get('OutputValue')))
         else:
             status = cfn.describe_stacks(StackName=stack_name).get("Stacks")[0].get('StackStatus')
             logger.info('Status: %s' % status)

--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -102,7 +102,7 @@ def run_test(region, distro, scheduler, key_name):
                                         'status', testname], stderr=stderr_f)
         dump_array = dump.splitlines()
         for line in dump_array:
-            m = re.search('MasterPublicIP"="(.+?)"', line)
+            m = re.search('MasterPublicIP: (.+?)', line)
             if m:
                 master_ip = m.group(1)
                 break


### PR DESCRIPTION
The output of the `cfncluster status` command has been cleaned with https://github.com/awslabs/cfncluster/pull/397 .

I'm removing a space before the semicolon to be aligned with the other following messages and I'm fixing the `cfncluster-release-check.py` to be able to cope with the new output format. 

### Output before #397 
```
Status: CREATE_COMPLETE
MasterServer: RUNNING
Output:"MasterPublicIP"="x.x.x.x"
Output:"MasterPrivateIP"="x.x.x.x"
Output:"GangliaPublicURL"="http://x.x.x.x/ganglia/"
Output:"GangliaPrivateURL"="http://x.x.x.x/ganglia/"
```

### Output after #397
```
Status: cfncluster-us-east-1-alinux-sge - CREATE_COMPLETE
MasterPublicIP : x.x.x.x
MasterPrivateIP : x.x.x.x
GangliaPublicURL : http://x.x.x.x/ganglia/
GangliaPrivateURL : http://x.x.x.x/ganglia/
```

### Output after this patch
```
Status: cfncluster-us-east-1-alinux-sge - CREATE_COMPLETE
MasterPublicIP: x.x.x.x
MasterPrivateIP: x.x.x.x
GangliaPublicURL: http://x.x.x.x/ganglia/
GangliaPrivateURL: http://x.x.x.x/ganglia/
```