### PR TITLE
Move Template URL Sanity Check

### DIFF
--- a/cli/cfncluster/cfnconfig.py
+++ b/cli/cfncluster/cfnconfig.py
@@ -172,6 +172,9 @@ class CfnClusterConfig(object):
                     if not self.template_url:
                         print("ERROR: template_url set in [%s] section but not defined." % self.__cluster_section)
                         sys.exit(1)
+                    if self.__sanity_check:
+                        config_sanity.check_resource(self.region, self.aws_access_key_id, self.aws_secret_access_key,
+                                                     'URL', self.template_url)
                 except configparser.NoOptionError:
                     if self.region == 'us-gov-west-1':
                         self.template_url = ('https://s3-%s.amazonaws.com/cfncluster-%s/templates/cfncluster-%s.cfn.json'
@@ -179,9 +182,6 @@ class CfnClusterConfig(object):
                     else:
                         self.template_url = ('https://s3.amazonaws.com/%s-cfncluster/templates/cfncluster-%s.cfn.json'
                                              % (self.region, self.version))
-            if self.__sanity_check:
-                config_sanity.check_resource(self.region,self.aws_access_key_id, self.aws_secret_access_key,
-                                             'URL', self.template_url)
         except AttributeError:
             pass
 


### PR DESCRIPTION
Move the sanity check to only check user provided
template url's. This resolves a bug where the url
generated by cfncluster returned a 301 in sanity
check but worked in stack creation.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.