### PR TITLE
Invoke bash shell with --login option to make ubuntu tests work

### DIFF
--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -119,7 +119,7 @@ def run_test(region, distro, scheduler, key_name, key_path):
         subprocess.check_call(['scp'] + ssh_params + ['cluster-check.sh', '%s@%s:.' % (username, master_ip)],
                               stdout=stdout_f, stderr=stderr_f)
         subprocess.check_call(
-            ['ssh'] + ssh_params + ['%s@%s' % (username, master_ip), '/bin/bash cluster-check.sh %s' % scheduler],
+            ['ssh'] + ssh_params + ['%s@%s' % (username, master_ip), '/bin/bash --login cluster-check.sh %s' % scheduler],
             stdout=stdout_f, stderr=stderr_f)
 
     except Exception as e:


### PR DESCRIPTION
When bash is invoked with the --login option, it loads the `/etc/profile`,
`~/.bash_profile`, `~/.bash_login`, and `~/.profile`.

We need the `/etc/profile` to have scheduler commands in the path.
Without this patch all the Ubuntu tests failed.

