### PR TITLE
CfnCluster Release Check script improvements

### DIFF
--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -58,7 +58,7 @@ success = 0
 # run a single test, possibly in parallel
 #
 def run_test(region, distro, scheduler, instance_type, key_name, key_path):
-    testname = '%s-%s-%s-%s' % (region, distro, scheduler, instance_type.replace('.', '-'))
+    testname = '%s-%s-%s-%s' % (region, distro, scheduler, instance_type.replace('.', ''))
     test_filename = "%s-config.cfg" % testname
 
     sys.stdout.write("--> %s: Starting\n" % (testname))
@@ -82,7 +82,10 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
     file.write("[global]\n")
     file.write("cluster_template = default\n")
     file.write("[scaling custom]\n")
-    file.write("scaling_adjustment = 2\n")
+    file.write("scaling_adjustment = 1\n")
+    file.write("scaling_period = 30\n")
+    file.write("scaling_evaluation_periods = 1\n")
+    file.write("scaling_cooldown = 300\n")
     file.close()
 
     stdout_f = open('%s-stdout.txt' % testname, 'w')
@@ -112,6 +115,7 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
             exception_raised = True
             raise Exception('Master IP not found')
         stdout_f.write("--> %s master ip: %s" % (testname, master_ip))
+        print("--> %s master ip: %s" % (testname, master_ip))
 
         # run test on the cluster...
         # ssh_params = ['-n'] # ssh only, not for scp

--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -90,6 +90,7 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
 
     master_ip = ''
     username = username_map[distro]
+    exception_raised = False;
 
     try:
         # build the cluster
@@ -107,9 +108,10 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
                 master_ip = m.group(1)
                 break
         if master_ip == '':
-            print('!! %s: Master IP not found; aborting !!' % (testname))
+            stderr_f.write('!! %s: Master IP not found; aborting !!' % (testname))
+            exception_raised = True
             raise Exception('Master IP not found')
-        print("--> %s master ip: %s" % (testname, master_ip))
+        stdout_f.write("--> %s master ip: %s" % (testname, master_ip))
 
         # run test on the cluster...
         ssh_params = ['-o', 'StrictHostKeyChecking=no']
@@ -123,13 +125,21 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
             stdout=stdout_f, stderr=stderr_f)
 
     except Exception as e:
-        sys.stdout.write("!! FAILURE: %s!!\n" % (testname))
+        stderr_f.write("!! FAILURE: %s!!\n" % (testname))
+        exception_raised = True
         raise e
 
     finally:
         # clean up the cluster
         subprocess.call(['cfncluster', '--config', test_filename, 'delete', testname],
                         stdout=stdout_f, stderr=stderr_f)
+        if exception_raised:
+            stdout_f.write('FAILURE: %s!!\n' % (testname))
+            open('%s.failed' %testname, 'w').close()
+        else:
+            stdout_f.write('SUCCESS:  %s!!\n' % (testname))
+            open('%s.success' %testname, 'w').close()
+
         stdout_f.close()
         stderr_f.close()
         os.remove(test_filename)

--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -72,7 +72,7 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
     file.write("base_os = %s\n" % distro)
     file.write("master_instance_type = %s\n" % instance_type)
     file.write("compute_instance_type = %s\n" % instance_type)
-    file.write("initial_queue_size = 2\n")
+    file.write("initial_queue_size = 1\n")
     file.write("maintain_initial_size = true\n")
     file.write("scheduler = %s\n" % (scheduler))
     file.write("scaling_settings = custom\n")

--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -118,7 +118,6 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
         print("--> %s master ip: %s" % (testname, master_ip))
 
         # run test on the cluster...
-        # ssh_params = ['-n'] # ssh only, not for scp
         ssh_params = ['-o', 'StrictHostKeyChecking=no']
         ssh_params += ['-o', 'BatchMode=yes']
         # ssh_params += ['-o', 'ConnectionAttempts=30']
@@ -131,7 +130,7 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
         subprocess.check_call(['scp'] + ssh_params + ['cluster-check.sh', '%s@%s:.' % (username, master_ip)],
                               stdout=stdout_f, stderr=stderr_f)
         subprocess.check_call(
-            ['ssh'] + ['-n'] + ssh_params + ['%s@%s' % (username, master_ip), '/bin/bash --login cluster-check.sh %s' % scheduler],
+            ['ssh', '-n'] + ssh_params + ['%s@%s' % (username, master_ip), '/bin/bash --login cluster-check.sh %s' % scheduler],
             stdout=stdout_f, stderr=stderr_f)
 
     except Exception as e:

--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -114,14 +114,20 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
         stdout_f.write("--> %s master ip: %s" % (testname, master_ip))
 
         # run test on the cluster...
+        # ssh_params = ['-n'] # ssh only, not for scp
         ssh_params = ['-o', 'StrictHostKeyChecking=no']
+        ssh_params += ['-o', 'BatchMode=yes']
+        # ssh_params += ['-o', 'ConnectionAttempts=30']
+        ssh_params += ['-o', 'ConnectTimeout=60']
+        ssh_params += ['-o', 'ServerAliveCountMax=5']
+        ssh_params += ['-o', 'ServerAliveInterval=30']
         if key_path:
             ssh_params.extend(['-i', key_path])
 
         subprocess.check_call(['scp'] + ssh_params + ['cluster-check.sh', '%s@%s:.' % (username, master_ip)],
                               stdout=stdout_f, stderr=stderr_f)
         subprocess.check_call(
-            ['ssh'] + ssh_params + ['%s@%s' % (username, master_ip), '/bin/bash --login cluster-check.sh %s' % scheduler],
+            ['ssh'] + ['-n'] + ssh_params + ['%s@%s' % (username, master_ip), '/bin/bash --login cluster-check.sh %s' % scheduler],
             stdout=stdout_f, stderr=stderr_f)
 
     except Exception as e:

--- a/tests/cluster-check.sh
+++ b/tests/cluster-check.sh
@@ -26,7 +26,7 @@
 # there's a bounded completion time
 if test "$CHECK_CLUSTER_SUBPROCESS" = ""; then
    export CHECK_CLUSTER_SUBPROCESS=1
-   timeout -s KILL 30m /bin/bash ./cluster-check.sh "$@"
+   timeout -s KILL 10m /bin/bash ./cluster-check.sh "$@"
    exit $?
 fi
 
@@ -45,34 +45,34 @@ set -e
 if test "$scheduler" = "slurm" ; then
     cat > job1.sh <<EOF
 #!/bin/bash
-srun sleep 960
+srun sleep 360
 touch job1.done
 EOF
     cat > job2.sh <<EOF
 #!/bin/bash
-srun sleep 960
+srun sleep 360
 touch job2.done
 EOF
 
     chmod +x job1.sh job2.sh
     rm -f job1.done job2.done
 
-    sbatch -N 2 ./job1.sh
-    sbatch -N 2 ./job2.sh
+    sbatch -N 1 ./job1.sh
+    sbatch -N 1 ./job2.sh
 
 elif test "$scheduler" = "sge" ; then
     # get the slots per node count of the first real node (one with a
     # architecture type of lx-?), so that we can reserve an enitre
     # node's worth of slots at a time.
     ppn=` qhost | grep 'lx-' | head -n 1 | sed -n -e 's/[^[:space:]]*[[:space:]]\+[^[:space:]]*[[:space:]]\+\([0-9]\+\).*/\1/p'`
-    count=$((ppn * 2))
+    count=$((ppn))
 
     cat > job1.sh <<EOF
 #!/bin/bash
 #$ -pe mpi $count
 #$ -R y
 
-sleep 960
+sleep 360
 touch job1.done
 EOF
     cat > job2.sh <<EOF
@@ -80,7 +80,7 @@ EOF
 #$ -pe mpi $count
 #$ -R y
 
-sleep 960
+sleep 360
 touch job2.done
 EOF
 
@@ -93,20 +93,20 @@ EOF
 elif test "$scheduler" = "torque" ; then
     cat > job1.sh <<EOF
 #!/bin/bash
-sleep 1200
+sleep 360
 touch job1.done
 EOF
     cat > job2.sh <<EOF
 #!/bin/bash
-sleep 1200
+sleep 360
 touch job2.done
 EOF
 
     chmod +x job1.sh job2.sh
     rm -f job1.done job2.done
 
-    qsub -l nodes=2:ppn=2 ./job1.sh
-    qsub -l nodes=2:ppn=2 ./job2.sh
+    qsub -l nodes=1:ppn=1 ./job1.sh
+    qsub -l nodes=1:ppn=1 ./job2.sh
 
 else
     echo "!! Unknown scheduler $scheduler !!"


### PR DESCRIPTION
Tuning a more aggressive scale-up 
Fix Torque node allocation + job sleep tuning
Added ssh options to better manage ssh connection

Torque: to fully allocate a job on one node we need to get the number of processor from the node list.

Scale-up: we need the system to launch the 2nd instance asap since the whole loop takes minutes.

Concerning job sleep, the sum of the two jbs sleep time should 
the timeout, so that if they would run on the same instance the whole
test would fail. At the same time we cannot simply split the full
timeout by 2 because the intance takes from 3 to 6 minutes to come up.
So we need to absorb this time during the computation of the first job.

Signed-off-by: Maurizio Melato <mmelato@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
