### PR TITLE
Update copyright year in the documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'CfnCluster'
-copyright = u'2014-2017, Amazon Web Services'
+copyright = u'2014-2018, Amazon Web Services'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
The copyright message is shown in the bottom of the [documentation](https://cfncluster.readthedocs.io) pages.