### PR TITLE
Consolidate Help Messages into Individual Commands

### DIFF
--- a/cli/cfncluster/cfnconfig.py
+++ b/cli/cfncluster/cfnconfig.py
@@ -52,7 +52,7 @@ class CfnClusterConfig(object):
         __args_func = self.args.func.__name__
 
         # Determine config file name based on args or default
-        if args.config_file is not None:
+        if hasattr(args, 'config_file') and args.config_file is not None:
             self.__config_file = args.config_file
         else:
             self.__config_file = os.path.expanduser(os.path.join('~', '.cfncluster', 'config'))
@@ -76,7 +76,7 @@ class CfnClusterConfig(object):
 
         # Determine the EC2 region to used used or default to us-east-1
         # Order is 1) CLI arg 2) AWS_DEFAULT_REGION env 3) Config file 4) us-east-1
-        if args.region:
+        if hasattr(args, 'region') and args.region:
             self.region = args.region
         else:
             if os.environ.get('AWS_DEFAULT_REGION'):

--- a/cli/cfncluster/cli.py
+++ b/cli/cfncluster/cli.py
@@ -73,19 +73,24 @@ def config_logger():
     fh.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(name)s - %(message)s'))
     logger.addHandler(fh)
 
+def addarg_config(subparser):
+    subparser.add_argument("--config", "-c", dest="config_file", help='specify a alternative config file')
+
+def addarg_region(subparser):
+    subparser.add_argument( "--region", "-r", dest="region", help='specify a specific region to connect to', default=None)
+
+def addarg_nowait(subparser):
+    subparser.add_argument( "--nowait", "-nw", dest="nowait", action='store_true',
+                    help='do not wait for stack events, after executing stack command')
+
 def main():
     config_logger()
 
     logger = logging.getLogger('cfncluster.cfncluster')
     logger.debug("CfnCluster cli starting")
 
-    parser = argparse.ArgumentParser(description='cfncluster is a tool to launch and manage a cluster.')
-    parser.add_argument("--config", "-c", dest="config_file", help='specify a alternative config file')
-    parser.add_argument( "--region", "-r", dest="region", help='specify a specific region to connect to',
-                        default=None)
-    parser.add_argument( "--nowait", "-nw", dest="nowait", action='store_true',
-                        help='do not wait for stack events, after executing stack command')
-
+    parser = argparse.ArgumentParser(description='cfncluster is a tool to launch and manage a cluster.',
+                                     epilog="For command specific flags run cfncluster [command] --help")
     subparsers = parser.add_subparsers()
     subparsers.required = True
     subparsers.dest = 'command'
@@ -93,6 +98,9 @@ def main():
     pcreate = subparsers.add_parser('create', help='creates a cluster')
     pcreate.add_argument("cluster_name", type=str, default=None,
                         help='create a cfncluster with the provided name.')
+    addarg_config(pcreate)
+    addarg_region(pcreate)
+    addarg_nowait(pcreate)
     pcreate.add_argument("--norollback", "-nr", action='store_true', dest="norollback", default=False,
                          help='disable stack rollback on error')
     pcreate.add_argument("--template-url", "-u", type=str, dest="template_url", default=None,
@@ -108,6 +116,9 @@ def main():
     pupdate = subparsers.add_parser('update', help='update a running cluster')
     pupdate.add_argument("cluster_name", type=str, default=None,
                         help='update a cfncluster with the provided name.')
+    addarg_config(pupdate)
+    addarg_region(pupdate)
+    addarg_nowait(pupdate)
     pupdate.add_argument("--norollback", "-nr", action='store_true', dest="norollback", default=False,
                          help='disable stack rollback on error')
     pupdate.add_argument("--template-url", "-u", type=str, dest="template_url", default=None,
@@ -123,32 +134,47 @@ def main():
     pdelete = subparsers.add_parser('delete', help='delete a cluster')
     pdelete.add_argument("cluster_name", type=str, default=None,
                         help='delete a cfncluster with the provided name.')
+    addarg_config(pdelete)
+    addarg_region(pdelete)
+    addarg_nowait(pdelete)
     pdelete.set_defaults(func=delete)
 
     pstart = subparsers.add_parser('start', help='start the compute-fleet that has been stopped')
     pstart.add_argument("cluster_name", type=str, default=None,
                         help='starts the compute-fleet of the provided cluster name.')
+    addarg_config(pstart)
+    addarg_region(pstart)
     pstart.set_defaults(func=start)
 
     pstop = subparsers.add_parser('stop', help='stop the compute-fleet, but leave the MasterServer running for debugging/development')
     pstop.add_argument("cluster_name", type=str, default=None,
                         help='stops the compute-fleet of the provided cluster name.')
+    addarg_config(pstop)
+    addarg_region(pstop)
     pstop.set_defaults(func=stop)
 
     pstatus = subparsers.add_parser('status', help='pull the current status of the cluster')
     pstatus.add_argument("cluster_name", type=str, default=None,
                         help='show the status of cfncluster with the provided name.')
+    addarg_config(pstatus)
+    addarg_region(pstatus)
+    addarg_nowait(pstatus)
     pstatus.set_defaults(func=status)
 
     plist = subparsers.add_parser('list', help='display a list of stacks associated with cfncluster')
+    addarg_config(plist)
+    addarg_region(plist)
     plist.set_defaults(func=list)
 
     pinstances = subparsers.add_parser('instances', help='display a list of all instances in a cluster')
     pinstances.add_argument("cluster_name", type=str, default=None,
                         help='show the status of cfncluster with the provided name.')
+    addarg_config(pinstances)
+    addarg_region(pinstances)
     pinstances.set_defaults(func=instances)
 
     pconfigure = subparsers.add_parser('configure', help='creating initial cfncluster configuration')
+    addarg_config(pconfigure)
     pconfigure.set_defaults(func=configure)
 
     pversion = subparsers.add_parser('version', help='display version of cfncluster')

--- a/cli/cfncluster/easyconfig.py
+++ b/cli/cfncluster/easyconfig.py
@@ -173,4 +173,3 @@ def configure(args):
 
     # Verify the configuration
     cfnconfig.CfnClusterConfig(args)
-

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -7,7 +7,7 @@
 CfnCluster Commands
 ###################
 
-Most commands provided are just wrappers around CloudFormation functions. 
+Most commands provided are just wrappers around CloudFormation functions.
 
 .. note:: When a command is called and it starts polling for status of that call it is safe to :code:`Ctrl-C` out. you can always return to that status by calling :code:`cfncluster status mycluster`
 
@@ -21,6 +21,11 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --config CONFIG_FILE, -c CONFIG_FILE
+                        specify a alternative config file
+  --region REGION, -r REGION
+                        specify a specific region to connect to
+  --nowait, -nw         do not wait for stack events, after executing stack command
   --norollback, -nr     disable stack rollback on error
   --template-url TEMPLATE_URL, -u TEMPLATE_URL
                         specify a URL for a custom cloudformation template
@@ -50,6 +55,11 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --config CONFIG_FILE, -c CONFIG_FILE
+                        specify a alternative config file
+  --region REGION, -r REGION
+                        specify a specific region to connect to
+  --nowait, -nw         do not wait for stack events, after executing stack command
   --norollback, -nr     disable stack rollback on error
   --template-url TEMPLATE_URL, -u TEMPLATE_URL
                         specify a URL for a custom cloudformation template
@@ -82,6 +92,10 @@ positional arguments:
 
 optional arguments:
   -h, --help    show this help message and exit
+  --config CONFIG_FILE, -c CONFIG_FILE
+                        specify a alternative config file
+  --region REGION, -r REGION
+                        specify a specific region to connect to
 
 ::
 
@@ -104,6 +118,10 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --config CONFIG_FILE, -c CONFIG_FILE
+                        specify a alternative config file
+  --region REGION, -r REGION
+                        specify a specific region to connect to
 
 ::
 
@@ -119,6 +137,11 @@ positional arguments:
 
 optional arguments:
   -h, --help    show this help message and exit
+  --config CONFIG_FILE, -c CONFIG_FILE
+                        specify a alternative config file
+  --region REGION, -r REGION
+                        specify a specific region to connect to
+  --nowait, -nw         do not wait for stack events, after executing stack command
 
 ::
 
@@ -135,6 +158,11 @@ positional arguments:
 
 optional arguments:
   -h, --help    show this help message and exit
+  --config CONFIG_FILE, -c CONFIG_FILE
+                        specify a alternative config file
+  --region REGION, -r REGION
+                        specify a specific region to connect to
+  --nowait, -nw         do not wait for stack events, after executing stack command
 
 ::
 
@@ -143,14 +171,18 @@ optional arguments:
 list
 ====
 
-Lists clusters currently running or stopped. Lists the :code:`stack_name` of the CloudFormation stacks with the name :code:`cfncluster-[stack_name]`. 
+Lists clusters currently running or stopped. Lists the :code:`stack_name` of the CloudFormation stacks with the name :code:`cfncluster-[stack_name]`.
 
 optional arguments:
   -h, --help  show this help message and exit
+  --config CONFIG_FILE, -c CONFIG_FILE
+                        specify a alternative config file
+  --region REGION, -r REGION
+                        specify a specific region to connect to
 
 ::
 
-    $ cfncluster list 
+    $ cfncluster list
 
 instances
 =========
@@ -162,9 +194,13 @@ positional arguments:
 
 optional arguments:
   -h, --help    show this help message and exit
+  --config CONFIG_FILE, -c CONFIG_FILE
+                        specify a alternative config file
+  --region REGION, -r REGION
+                        specify a specific region to connect to
 
 ::
-    
+
     $ cfncluster instances mycluster
 
 configure
@@ -174,9 +210,11 @@ Configures the cluster. See `Configuring CfnCluster <https://cfncluster.readthed
 
 optional arguments:
   -h, --help  show this help message and exit
+  --config CONFIG_FILE, -c CONFIG_FILE
+                        specify a alternative config file
 
 ::
-    
+
     $ cfncluster configure mycluster
 
 version
@@ -186,6 +224,8 @@ Displays CfnCluster version.
 
 optional arguments:
   -h, --help  show this help message and exit
+  --region REGION, -r REGION
+                        specify a specific region to connect
 
 ::
 


### PR DESCRIPTION
Previously, the output of `cfncluster --help` differed
from the output of `cfncluster create --help`, this lead
to confusion. Now you don't see any flags when you run `cfncluster --help`
and the subcommands each have flags specific to that command.

This also fixes a long standing bug where to check the installation
of cfncluster, you run `cfncluster version` however this requires a
config file which has not been generated first.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.