### PR TITLE
Improve configuration file parsing error messages

### DIFF
--- a/cli/cfncluster/cfnconfig.py
+++ b/cli/cfncluster/cfnconfig.py
@@ -213,6 +213,10 @@ class CfnClusterConfig(object):
                 self.parameters.append((self.__vpc_options.get(key)[0],__temp__))
             except configparser.NoOptionError:
                 pass
+            except configparser.NoSectionError:
+                print("ERROR: VPC section [%s] used in [%s] section is not defined"
+                      % (self.__vpc_section, self.__cluster_section))
+                sys.exit(1)
 
         # Dictionary list of all cluster section options
         self.__cluster_options = dict(cluster_user=('ClusterUser', None), compute_instance_type=('ComputeInstanceType',None),


### PR DESCRIPTION
Print a clear error message when a VPC section is used but not defined rather than raising an exception.

This improve the user experience in cases like #426.

Old behaviour was:
```
Traceback (most recent call last):
File "cfncluster", line 11, in <module>
  sys.exit(main())
[...]
File "[...]dist-packages/backports/configparser/__init__.py", line 1162, in _unify_values
    raise NoSectionError(section)
backports.configparser.NoSectionError: No section: u'vpc my-vpc'
```
New behaviour is:
```
ERROR: VPC section [vpc my-vpc] set in [cluster my-cluster] section is not defined
```