### PR TITLE
Fix the cycle time to 15 secs for Torque

### DIFF
--- a/tests/cluster-check.sh
+++ b/tests/cluster-check.sh
@@ -48,7 +48,7 @@ torque_get_slots() {
 
     chost=$({ pbsnodes -l free ; pbsnodes -l job-exclusive; } | head -n 1 | cut -d ' ' -f1)
     # wait 15 secs before giving up retrieving the slots per host
-    while [ -z "${chost}" -a $i -lt 1 ]; do
+    while [ -z "${chost}" -a $i -lt 15 ]; do
         sleep 1
         i=$((i+1))
         chost=$({ pbsnodes -l free ; pbsnodes -l job-exclusive; } | head -n 1 | cut -d ' ' -f1)


### PR DESCRIPTION
Of 45 tests (clusters) I got 4 failures for 4 (of 15) Torque clusters. All had the same issue:
```
The number of slots per instance couldn't be retrieved, no compute nodes available in Torque cluster
```
The cycle trying to retrieve the number of slots per instance was waiting for just 1 sec instead of 15.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
