### PR TITLE
 Improve cfncluster-release-check integration test

### DIFF
--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -118,12 +118,12 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
     _create_done = False;
     try:
         # build the cluster
-        prochelp.exec_command(['cfncluster', '--config', test_filename, 'create', testname],
+        prochelp.exec_command(['cfncluster', 'create', '--config', test_filename, testname],
                               stdout=stdout_f, stderr=stderr_f)
         _create_done = True
         # get the master ip, which means grepping through cfncluster status gorp
-        dump = prochelp.exec_command(['cfncluster', '--config', test_filename,
-                                        'status', testname], stderr=stderr_f)
+        dump = prochelp.exec_command(['cfncluster', 'status', '--config', test_filename,
+                                        testname], stderr=stderr_f)
         dump_array = dump.splitlines()
         for line in dump_array:
             m = re.search('MasterPublicIP: (.+)$', line)
@@ -184,7 +184,7 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
             while not _del_done and _del_iters > 0:
                 try:
                     # clean up the cluster
-                    _del_output = sub.check_output(['cfncluster', '--config', test_filename, '-nw', 'delete', testname], stderr=stderr_f)
+                    _del_output = sub.check_output(['cfncluster', 'delete', '--config', test_filename, '-nw', testname], stderr=stderr_f)
                     _del_done = "DELETE_IN_PROGRESS" in _del_output or "DELETE_COMPLETE" in _del_output
                     stdout_f.write(_del_output + '\n')
                 except sub.CalledProcessError as exc:
@@ -198,7 +198,7 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
                     _del_iters -= 1
 
             try:
-                prochelp.exec_command(['cfncluster', '--config', test_filename, 'status', testname], stdout=stdout_f, stderr=stderr_f)
+                prochelp.exec_command(['cfncluster', 'status', '--config', test_filename, testname], stdout=stdout_f, stderr=stderr_f)
             except sub.CalledProcessError as exc:
                 # Usually it terminates with exit status 1 since at the end of the delete operation the stack is not found.
                 stdout_f.write("Expected CalledProcessError exception launching 'cfncluster status': %s - Output:\n%s\n" % (str(exc), exc.output))
@@ -420,10 +420,7 @@ def _main_child():
 
 if __name__ == '__main__':
     _child = os.fork()
-    #===========================================================================
-    # sys.stdout = open(('pid-%s-stdout.txt' % os.getpid()), 'w', 0)
-    # sys.stderr = open(('pid-%s-stderr.txt' % os.getpid()), 'w', 0)
-    #===========================================================================
+
     if _child == 0:
         _main_child()
     else:

--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -26,14 +26,20 @@
 #   (value does not matter). That subnet will be used as the launch
 #   target for the cluster.
 
+import datetime
+import errno
 import os
+import signal
 import sys
-import subprocess
+import subprocess as sub
 import threading
+import time
 import re
 import argparse
 import Queue
 import boto3
+import process_helper as prochelp
+from builtins import exit
 
 #
 # configuration
@@ -52,13 +58,28 @@ setup = {}
 results_lock = threading.Lock()
 failure = 0
 success = 0
+aborted = 0
 
+# PID of the actual test process
+_child = 0
+# True if parent process has been asked to terminate
+_termination_caught = False
+
+_TIMESTAMP_FORMAT = '%Y%m%d%H%M%S'
+_timestamp = datetime.datetime.now().strftime(_TIMESTAMP_FORMAT)
+
+
+def _dirname():
+    return os.path.dirname(os.path.realpath(sys.argv[0]))
+
+def _time():
+    return datetime.datetime.now()
 
 #
 # run a single test, possibly in parallel
 #
 def run_test(region, distro, scheduler, instance_type, key_name, key_path):
-    testname = '%s-%s-%s-%s' % (region, distro, scheduler, instance_type.replace('.', ''))
+    testname = '%s-%s-%s-%s-%s' % (region, distro, scheduler, instance_type.replace('.', ''), _timestamp)
     test_filename = "%s-config.cfg" % testname
 
     sys.stdout.write("--> %s: Starting\n" % (testname))
@@ -88,21 +109,20 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
     file.write("scaling_cooldown = 300\n")
     file.close()
 
-    stdout_f = open('%s-stdout.txt' % testname, 'w')
-    stderr_f = open('%s-stderr.txt' % testname, 'w')
+    stdout_f = open('%s-stdout.txt' % testname, 'w', 0)
+    stderr_f = open('%s-stderr.txt' % testname, 'w', 0)
 
     master_ip = ''
     username = username_map[distro]
-    exception_raised = False;
-
+    _create_interrupted = False;
+    _create_done = False;
     try:
         # build the cluster
-        subprocess.check_call(['cfncluster', '--config', test_filename,
-                               'create', testname],
+        prochelp.exec_command(['cfncluster', '--config', test_filename, 'create', testname],
                               stdout=stdout_f, stderr=stderr_f)
-
+        _create_done = True
         # get the master ip, which means grepping through cfncluster status gorp
-        dump = subprocess.check_output(['cfncluster', '--config', test_filename,
+        dump = prochelp.exec_command(['cfncluster', '--config', test_filename,
                                         'status', testname], stderr=stderr_f)
         dump_array = dump.splitlines()
         for line in dump_array:
@@ -111,11 +131,10 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
                 master_ip = m.group(1)
                 break
         if master_ip == '':
-            stderr_f.write('!! %s: Master IP not found; aborting !!' % (testname))
-            exception_raised = True
-            raise Exception('Master IP not found')
-        stdout_f.write("--> %s master ip: %s" % (testname, master_ip))
-        print("--> %s master ip: %s" % (testname, master_ip))
+            stderr_f.write('!! %s: Master IP not found; aborting !!\n' % (testname))
+            raise Exception('--> %s: Master IP not found!' % testname)
+        stdout_f.write("--> %s Master IP: %s\n" % (testname, master_ip))
+        print("--> %s Master IP: %s" % (testname, master_ip))
 
         # run test on the cluster...
         ssh_params = ['-o', 'StrictHostKeyChecking=no']
@@ -127,32 +146,67 @@ def run_test(region, distro, scheduler, instance_type, key_name, key_path):
         if key_path:
             ssh_params.extend(['-i', key_path])
 
-        subprocess.check_call(['scp'] + ssh_params + ['cluster-check.sh', '%s@%s:.' % (username, master_ip)],
+        prochelp.exec_command(['scp'] + ssh_params + [os.path.join(_dirname(), 'cluster-check.sh'), '%s@%s:.' % (username, master_ip)],
                               stdout=stdout_f, stderr=stderr_f)
-        subprocess.check_call(
-            ['ssh', '-n'] + ssh_params + ['%s@%s' % (username, master_ip), '/bin/bash --login cluster-check.sh %s' % scheduler],
-            stdout=stdout_f, stderr=stderr_f)
+        prochelp.exec_command(['ssh', '-n'] + ssh_params + ['%s@%s' % (username, master_ip), '/bin/bash --login cluster-check.sh %s' % scheduler],
+                              stdout=stdout_f, stderr=stderr_f)
 
-    except Exception as e:
-        stderr_f.write("!! FAILURE: %s!!\n" % (testname))
-        exception_raised = True
-        raise e
-
+        stdout_f.write('SUCCESS:  %s!!\n' % (testname))
+        open('%s.success' %testname, 'w').close()
+    except prochelp.ProcessHelperError as exc:
+        if not _create_done and isinstance(exc, prochelp.KilledProcessError):
+            _create_interrupted = True
+            print("--> %s: Interrupting cfncluster create!" % testname)
+        print('!! ABORTED: %s!!' % (testname))
+        stdout_f.write('ABORTED: %s!!\n' % (testname))
+        open('%s.aborted' % testname, 'w').close()
+        raise exc
+    except Exception as exc:
+        if not _create_done:
+            _create_interrupted = True
+        print("Unexpected exception %s: %s" % (str(type(exc)), str(exc)))
+        stdout_f.write("Unexpected exception %s: %s\n" % (str(type(exc)), str(exc)))
+        sys.stdout.write("!! FAILURE: %s!!\n" % (testname))
+        stdout_f.write('FAILURE: %s!!\n' % (testname))
+        open('%s.failed' % testname, 'w').close()
+        raise exc
     finally:
-        # clean up the cluster
-        subprocess.call(['cfncluster', '--config', test_filename, 'delete', testname],
-                        stdout=stdout_f, stderr=stderr_f)
-        if exception_raised:
-            stdout_f.write('FAILURE: %s!!\n' % (testname))
-            open('%s.failed' %testname, 'w').close()
+        if _create_interrupted or _create_done:
+            # if the create process was interrupted it may take few seconds for the stack id to be actually registered
+            _max_del_iters = _del_iters = 10
         else:
-            stdout_f.write('SUCCESS:  %s!!\n' % (testname))
-            open('%s.success' %testname, 'w').close()
+            # No delete is necessary if cluster creation wasn't started (process_helper.AbortedProcessError)
+            _del_iters = 0
+        if _del_iters > 0:
+            _del_done = False
+            stdout_f.write('Deleting: %s - max iterations: %s\n' % (testname, _del_iters))
+            print("--> %s: Deleting - max iterations: %s" % (testname, _del_iters))
+            while not _del_done and _del_iters > 0:
+                try:
+                    # clean up the cluster
+                    _del_output = sub.check_output(['cfncluster', '--config', test_filename, '-nw', 'delete', testname], stderr=stderr_f)
+                    _del_done = "DELETE_IN_PROGRESS" in _del_output or "DELETE_COMPLETE" in _del_output
+                    stdout_f.write(_del_output + '\n')
+                except sub.CalledProcessError as exc:
+                    stdout_f.write("CalledProcessError exception launching 'cfncluster delete': %s - Output:\n%s\n" % (str(exc), exc.output))
+                except Exception as exc:
+                    stdout_f.write("Unexpected exception launching 'cfncluster delete' %s: %s\n" % (str(type(exc)), str(exc)))
+                finally:
+                    print("--> %s: Deleting - iteration: %s - successfully submitted: %s" % (testname, (_max_del_iters - _del_iters + 1), _del_done))
+                    if not _del_done and _del_iters > 1:
+                        time.sleep(2)
+                    _del_iters -= 1
 
+            try:
+                prochelp.exec_command(['cfncluster', '--config', test_filename, 'status', testname], stdout=stdout_f, stderr=stderr_f)
+            except sub.CalledProcessError as exc:
+                # Usually it terminates with exit status 1 since at the end of the delete operation the stack is not found.
+                stdout_f.write("Expected CalledProcessError exception launching 'cfncluster status': %s - Output:\n%s\n" % (str(exc), exc.output))
+            except Exception as exc:
+                stdout_f.write("Unexpected exception launching 'cfncluster status' %s: %s\n" % (str(type(exc)), str(exc)))
         stdout_f.close()
         stderr_f.close()
-        os.remove(test_filename)
-
+    sys.stdout.write("--> %s: Finished\n" % (testname))
 
 #
 # worker thread, there will be config['parallelism'] of these running
@@ -166,14 +220,17 @@ def test_runner(region, q, key_name, key_path):
     while True:
         item = q.get()
 
+        retval = 1
         # just in case we miss an exception in run_test, don't abort everything...
         try:
-            run_test(region=region, distro=item['distro'], scheduler=item['scheduler'],
-                     instance_type=item['instance_type'], key_name=key_name, key_path=key_path)
-            retval = 0
-        except Exception as e:
-            print("Unexpected exception %s: %s" % (str(type(e)), str((e))))
-            retval = 1
+            if not prochelp.termination_caught():
+                run_test(region=region, distro=item['distro'], scheduler=item['scheduler'],
+                         instance_type=item['instance_type'], key_name=key_name, key_path=key_path)
+                retval = 0
+        except (prochelp.ProcessHelperError, sub.CalledProcessError):
+            pass
+        except Exception as exc:
+            print("[test_runner] Unexpected exception %s: %s\n" % (str(type(exc)), str(exc)))
 
         results_lock.acquire(True)
         if retval == 0:
@@ -183,8 +240,74 @@ def test_runner(region, q, key_name, key_path):
         results_lock.release()
         q.task_done()
 
+def _term_handler(_signo, _stack_frame):
+    global _termination_caught
 
-if __name__ == '__main__':
+    if not _termination_caught:
+        _termination_caught = True
+        print("Termination handler setting _termination_caught = True")
+        print("Sending TERM signal to child process %s" % _child)
+        os.kill(_child, signal.SIGTERM)
+
+def _bind_signals_parent():
+    #    signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    signal.signal(signal.SIGINT, _term_handler)
+    signal.signal(signal.SIGTERM, _term_handler)
+    signal.signal(signal.SIGHUP, _term_handler)
+
+def _main_parent():
+    _bind_signals_parent()
+    print("Child pid: %s" % _child)
+    status = 0
+    child_terminated = False
+    max_num_exc = 10
+    while not child_terminated and max_num_exc > 0:
+        try:
+            (pid, status) = os.wait()
+            child_terminated = True
+        except OSError as ose:
+            # errno.ECHILD -
+            child_terminated = ose.errno == errno.ECHILD
+            if not child_terminated:
+                print("OSError exception while waiting for child process %s, errno: %s - %s" % (_child, errno.errorcode[ose.errno], str(ose)))
+        except BaseException as exc:
+            print("Unexpected exception while waiting for child process %s, %s: %s" % (_child, str(type(exc)), str(exc)))
+            max_num_exc -= 1
+    print("Child pid: %s - Exit status: %s" % (pid, status))
+    exit(status)
+
+def _bind_signals_child():
+    # This is important - otherwise SIGINT propagates downstream to threads and child processes
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    # signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    signal.signal(signal.SIGTERM, prochelp.term_handler)
+    signal.signal(signal.SIGHUP, prochelp.term_handler)
+
+def _proc_alive(pid):
+    if pid <= 1:
+        return False
+    alive = False
+    try:
+        # No real signal is sent but error checking is performed
+        os.kill(pid, 0)
+        alive = True
+    except OSError as ose:
+        # ose.errno == errno.EINVAL - Invalid signal number (this shouldn't happen)
+        # ose.errno == errno.ESRCH - No such process
+        # ose.errno == errno.EPERM - No permissions to check 'pid' process.
+        pass
+    except Exception as exc:
+        print("Unexpected exception checking process %s, %s: %s" % (pid, str(type(exc)), str(exc)))
+
+    return alive
+
+def _killme_gently():
+    os.kill(os.getpid(), signal.SIGTERM)
+
+def _main_child():
+    _bind_signals_child()
+    parent = os.getppid()
+    print("Parent pid: %s" % parent)
     config = { 'parallelism' : 3,
                'regions' : 'us-east-1,us-east-2,us-west-1,us-west-2,' +
                            'ca-central-1,eu-west-1,eu-west-2,eu-central-1,' +
@@ -221,11 +344,12 @@ if __name__ == '__main__':
     instance_type_list = config['instance_types'].split(',')
 
     print("==> Regions: %s" % (', '.join(region_list)))
+    print("==> Instance Types: %s" % (', '.join(instance_type_list)))
     print("==> Distros: %s" % (', '.join(distro_list)))
     print("==> Schedulers: %s" % (', '.join(scheduler_list)))
     print("==> Parallelism: %d" % (config['parallelism']))
-    print("==> Instance Types: %s" % (', '.join(instance_type_list)))
     print("==> Key Pair: %s" % (config['key_name']))
+
     if config['key_path']:
         print("==> Key Path: %s" % (config['key_path']))
 
@@ -249,7 +373,6 @@ if __name__ == '__main__':
 
         setup[region] = { 'vpc' : vpcid, 'subnet' : subnetid }
 
-
     work_queues = {}
     # build up a per-region list of work to do
     for region in region_list:
@@ -268,12 +391,40 @@ if __name__ == '__main__':
             t.daemon = True
             t.start()
 
+
+    # WARN: The join() approach prevents the SIGINT signal to be caught from the main thread,
+    #       that is actually blocked in the join.
     # wait for all the work queues to be completed in each region
-    for region in region_list:
-        work_queues[region].join()
+    # for region in region_list:
+    #    work_queues[region].join()
+    all_finished = False
+    self_killed = False
+    while not all_finished:
+        time.sleep(1)
+        all_finished = True
+        for queue in work_queues.values():
+            all_finished = all_finished and queue.unfinished_tasks == 0
+        # If parent process is SIGKILL-ed
+        if not _proc_alive(parent) and not self_killed:
+            print("Parent process with pid %s died - terminating..." % parent)
+            _killme_gently()
+            self_killed = True
+
+    print("%s - Reqions workers queues all done: %s" % (_time(), all_finished))
 
     # print status...
     print("==> Success: %d" % (success))
     print("==> Failure: %d" % (failure))
     if failure != 0:
         exit(1)
+
+if __name__ == '__main__':
+    _child = os.fork()
+    #===========================================================================
+    # sys.stdout = open(('pid-%s-stdout.txt' % os.getpid()), 'w', 0)
+    # sys.stderr = open(('pid-%s-stderr.txt' % os.getpid()), 'w', 0)
+    #===========================================================================
+    if _child == 0:
+        _main_child()
+    else:
+        _main_parent()

--- a/tests/process_helper.py
+++ b/tests/process_helper.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python
+#
+# Copyright 2018      Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy
+# of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+#
+# It helps with the termination of multiple processes forked by a simple multi-threaded application.
+# All processes are registered internally and if the term_handler() function is registered
+# to handle TERM or INT signals it will kill all the active processes submitted through the exec_command() function.
+# Killed processes would make the exec_command() function to raise an Exception (either AbortedProcessError,
+# KilledProcessError or CalledProcessError) that can be managed by the client application.
+#
+
+import os
+import signal
+import subprocess as sub
+import threading
+
+
+_procs = {}
+_procs_lock = threading.Lock()
+
+_termination_caught = False
+
+class ProcessHelperError(Exception):
+    def __init__(self, cmd, msg=None):
+        if msg is None:
+            msg = "Error executing command '%s' was killed" % cmd
+        super(ProcessHelperError, self).__init__(msg)
+        self.cmd = cmd
+
+class AbortedProcessError(ProcessHelperError):
+    def __init__(self, cmd):
+        super(AbortedProcessError, self).__init__(cmd, "Command '%s' was aborted" % cmd)
+
+class KilledProcessError(ProcessHelperError):
+    def __init__(self, cmd):
+        super(KilledProcessError, self).__init__(cmd, "Process for command '%s' was killed" % cmd)
+
+def termination_caught():
+    return _termination_caught
+
+#
+# This function is supposed to be used as handler for system signals:
+#    signal.signal(signal.SIGTERM, ph.term_handler)
+# It manages to kill all the active processes submitted through this module.
+# Killed processes would make the exec_command() function to raise a KilledProcessError
+# or an AbortedProcessError.
+#
+def term_handler(_signo, _stack_frame):
+    global _procs_lock, _procs, _termination_caught
+
+    _procs_lock.acquire()
+    if not _termination_caught:
+        _termination_caught = True
+        for proc in _procs.values():
+            _kill_process(proc)
+
+    _procs_lock.release()
+
+def _kill_process(process):
+    try:
+        process.kill()
+    except:
+        pass
+
+def _add_process(process):
+    global _procs_lock, _procs, _termination_caught
+
+    if process != None and process.pid != None and process.pid != 0:
+        _procs_lock.acquire()
+
+        if _termination_caught:
+            _kill_process(process)
+        else:
+            _procs[process.pid] = process
+
+        _procs_lock.release()
+
+def _remove_process(process):
+    global _procs_lock, _procs
+
+    if process != None and _procs.has_key(process.pid):
+        _procs_lock.acquire()
+
+        del _procs[process.pid]
+
+        _procs_lock.release()
+
+def exec_command(*cmdargs, **kwargs):
+    global _termination_caught
+
+    if _termination_caught:
+        raise AbortedProcessError(" ".join(*cmdargs))
+
+    DEV_NULL = open(os.devnull, "rb")
+    params = {
+        'env' : dict(os.environ),
+        'stdin' : DEV_NULL,
+        'stdout' : sub.PIPE,
+        'stderr' : sub.STDOUT
+        }
+    params.update(kwargs)
+
+    process = None
+    try:
+        process = sub.Popen(*cmdargs, **params)
+        _add_process(process)
+        stdout = process.communicate()[0]
+        exitcode = process.poll()
+        if exitcode != 0:
+            if _termination_caught:
+                raise KilledProcessError(" ".join(*cmdargs))
+            else:
+                raise sub.CalledProcessError(exitcode, " ".join(*cmdargs), stdout)
+        return stdout
+    finally:
+        DEV_NULL.close()
+        _remove_process(process)

--- a/tests/process_helper.py
+++ b/tests/process_helper.py
@@ -14,11 +14,11 @@
 # language governing permissions and limitations under the License.
 #
 #
-# It helps with the termination of multiple processes forked by a simple multi-threaded application.
+# This helper class copes with the termination of multiple processes forked by a simple multi-threaded application.
 # All processes are registered internally and if the term_handler() function is registered
 # to handle TERM or INT signals it will kill all the active processes submitted through the exec_command() function.
-# Killed processes would make the exec_command() function to raise an Exception (either AbortedProcessError,
-# KilledProcessError or CalledProcessError) that can be managed by the client application.
+# Killed processes would make the exec_command() function to raise an Exception, either AbortedProcessError or
+# KilledProcessError, that can be managed by the client application.
 #
 
 import os
@@ -55,7 +55,7 @@ def termination_caught():
 #    signal.signal(signal.SIGTERM, ph.term_handler)
 # It manages to kill all the active processes submitted through this module.
 # Killed processes would make the exec_command() function to raise a KilledProcessError
-# or an AbortedProcessError.
+# or an AbortedProcessError exception.
 #
 def term_handler(_signo, _stack_frame):
     global _procs_lock, _procs, _termination_caught


### PR DESCRIPTION
## Improve release-check termination

cfncluster-release-check integration test runs for few hours spawning tens of clusters across the supported regions. Interrupting this process means to leave a number of clusters up and running.

This patch wants to gracefully manage the interrupted termination, cleaning all the clusters that have been created.
This is obtained with the following changes
1. Capture the terminate/interrupt signals and manage the termination of the running processes. This will raise an exception in all those threads where the main operations are running and prevents further commands to be executed. The finally block then copes with the removal of the
created clusters.
2. The name of the cluster has been made reasonably unique by adding the timestamp of the launch. In this way we have not to wait all the clusters to be deleted and we can launch a second instance.
3. The delete cluster operation is now not suspensive.

### Change top level process mgt and signal handling

`tests/cfncluster-release-check.py` has been refactored in order to split 
execution into a parent + child processes.
Child process is the actual tests runner. Since python propagates SIGINT signal to threads and sub-processes in an unpredictable and unmanageable way, SIGINT is ignored by the child process that manages instead the SIGTERM/SIGHUP signals.
Upon receiving a SIGTERM signal all the processes are killed and all clusters deleted.
Due to racing conditions when trying to delete a cluster that is just at the  very early stages of its creation, 'cluster delete' has been made more robust by retrying a number of times when the system recognizes the 'cluster create' was interrupted.
The main cycle that waits for all the worker threads to complete was changed in order to avoid the join() call that would prevent the application from correctly handling signals.
The child process also copes with situations where the parent process has been killed by a SIGKILL and in this case the child suicides.

Parent process is aimed to capture the process termination signals and to send a SIGTERM to the child. In any case the parent process waits for the child to terminate.

### Align cfncluster command line arguments order

With PR https://github.com/awslabs/cfncluster/pull/435 the options for commands have been fixed, e.g. '--config' can be used for create, status and delete but not for version.
Invocations of cfncluster have been changed accordingly.

### Error management and messaging 
Redirect stderr to stdout, it's easier to correlate the errors to the activity logging.
Avoid to start running a test, i.e. creating the configuration, stdout, stderr files etc. when a termination signals has already been caught.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
