### PR TITLE
Update Chef version to be consistent with cookbook package

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -1769,9 +1769,9 @@
       "default": {
         "cfncluster": "cfncluster-1.5.1",
         "cookbook": "cfncluster-cookbook-1.5.1",
-        "chef": "12.19.36",
-        "ridley": "5.1.0",
-        "berkshelf": "5.6.4",
+        "chef": "14.2.0",
+        "ridley": "5.1.1",
+        "berkshelf": "7.0.4",
         "ami": "dev"
       }
     },


### PR DESCRIPTION
Chef version was updated in the cookbook package, see
https://github.com/awslabs/cfncluster-cookbook/commit/7228ae631156be917319af526cb829dbfacf2844
and
https://github.com/awslabs/cfncluster-cookbook/commit/9b57a4cdd67e140bc27a20b64e97a09f18912e64

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
