### PR TITLE
Clean the directory in which vendored cookbooks will be placed

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -2761,7 +2761,7 @@
           "getCookbooks": {
             "commands": {
               "berk": {
-                "command": ". /tmp/proxy.sh; for d in `ls /tmp/cookbooks`; do cd /tmp/cookbooks/$d;LANG=en_US.UTF-8 /opt/chef/embedded/bin/berks vendor /etc/chef/cookbooks; done ",
+                "command": ". /tmp/proxy.sh; for d in `ls /tmp/cookbooks`; do cd /tmp/cookbooks/$d;LANG=en_US.UTF-8 /opt/chef/embedded/bin/berks vendor /etc/chef/cookbooks --delete; done ",
                 "cwd": "/tmp/cookbooks",
                 "env": {
                   "HOME": "/tmp"
@@ -3460,7 +3460,7 @@
           "getCookbooks": {
             "commands": {
               "berk": {
-                "command": ". /tmp/proxy.sh; for d in `ls /tmp/cookbooks`; do cd /tmp/cookbooks/$d;LANG=en_US.UTF-8 /opt/chef/embedded/bin/berks vendor /etc/chef/cookbooks; done ",
+                "command": ". /tmp/proxy.sh; for d in `ls /tmp/cookbooks`; do cd /tmp/cookbooks/$d;LANG=en_US.UTF-8 /opt/chef/embedded/bin/berks vendor /etc/chef/cookbooks --delete; done ",
                 "cwd": "/tmp/cookbooks",
                 "env": {
                   "HOME": "/tmp"


### PR DESCRIPTION
Clean the directory in which vendored cookbooks will be placed prior to
execute the vendor command.
This solve the problem when a cookbook dependency needs to be updated,
e.g. when Chef version is upgraded.
Without cleaning up the directory, which contains the cookbook cache
store built during the AMI creation, the old version of the cookbook
dependency will be used, potentially breaking the new requirements
of the new Chef version.

see https://github.com/berkshelf/berkshelf/issues/381 for details.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

Tested through the deploy of a new cluster with a custom template containing the patch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
