### PR TITLE
Add missing policy for CfnCluster user profile

### DIFF
--- a/docs/source/iam.rst
+++ b/docs/source/iam.rst
@@ -8,7 +8,7 @@ IAM in CfnCluster
 
 
 CfnCluster utilizes multiple AWS services to deploy and operate a cluster. The services used are listed in the :ref:`AWS Services used in CfnCluster <aws_services>` section of the documentation.
- 
+
 CfnCluster uses EC2 IAM roles to enable instances access to AWS services for the deployment and operation of the cluster. By default the EC2 IAM role is created as part of the cluster creation by CloudFormation. This means that the user creating the cluster must have the appropriate level of permissions
 
 Defaults
@@ -176,7 +176,9 @@ CfnClusterUserPolicy
                   "ec2:DeleteSecurityGroup",
                   "ec2:DisassociateAddress",
                   "ec2:RevokeSecurityGroupIngress",
-                  "ec2:ReleaseAddress"
+                  "ec2:ReleaseAddress",
+                  "ec2:CreatePlacementGroup",
+                  "ec2:DeletePlacementGroup"
               ],
               "Effect": "Allow",
               "Resource": "*"
@@ -308,7 +310,9 @@ CfnClusterUserPolicy
               "Action": [
                   "iam:PassRole",
                   "iam:CreateRole",
-                  "iam:DeleteRole"
+                  "iam:DeleteRole",
+                  "iam:GetRole",
+                  "iam:SimulatePrincipalPolicy"
               ],
               "Effect": "Allow",
               "Resource": "arn:aws:iam::<AWS ACCOUNT ID>:role/<CFNCLUSTER EC2 ROLE NAME>"


### PR DESCRIPTION
"ec2:CreatePlacementGroup" and "ec2:DeletePlacementGroup" used
when setting the placement group config option to be DYNAMIC

"iam:GetRole" and "iam:SimulatePrincipalPolicy" used when setting
a custom instance role

This solve https://github.com/awslabs/cfncluster/issues/473

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
