### PR TITLE
Increase scaledown idle time and the timeout on scale down check

### DIFF
--- a/tests/cfncluster-release-check.py
+++ b/tests/cfncluster-release-check.py
@@ -134,7 +134,7 @@ def run_test(region, distro, scheduler, instance_type, key_name, extra_args):
     file.write("[global]\n")
     file.write("cluster_template = default\n")
     file.write("[scaling custom]\n")
-    file.write("scaledown_idletime = 2\n")
+    file.write("scaledown_idletime = 3\n")
     file.close()
 
     out_f = open('%s-out.txt' % testname, 'w', 0)

--- a/tests/cluster-check.sh
+++ b/tests/cluster-check.sh
@@ -215,7 +215,7 @@ scaledown_check_launch() {
     # bounded completion time
     if test "$CHECK_CLUSTER_SUBPROCESS" = ""; then
         export CHECK_CLUSTER_SUBPROCESS=1
-        timeout -s KILL 3m /bin/bash ./cluster-check.sh "$@"
+        timeout -s KILL 5m /bin/bash ./cluster-check.sh "$@"
         exit $?
     fi
 


### PR DESCRIPTION
A buffer of more than a minute is needed for the instance to be shutdown and detached from queue

Signed-off-by: Balaji Sridharan <fnubalaj@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
