### PR TITLE
Reduce polling asg interval and timeout for scaledown check

### DIFF
--- a/tests/cluster-check.sh
+++ b/tests/cluster-check.sh
@@ -215,7 +215,7 @@ scaledown_check_launch() {
     # bounded completion time
     if test "$CHECK_CLUSTER_SUBPROCESS" = ""; then
         export CHECK_CLUSTER_SUBPROCESS=1
-        timeout -s KILL 5m /bin/bash ./cluster-check.sh "$@"
+        timeout -s KILL 4m /bin/bash ./cluster-check.sh "$@"
         exit $?
     fi
 


### PR DESCRIPTION
Poll asg for reduced capacity every 10 seconds for 4 minutes
Reduce scaledown_check timeout to 4 minutes

Signed-off-by: Balaji Sridharan <fnubalaj@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
