### PR TITLE
Add credentials to sts call in check_resources

### DIFF
--- a/cli/cfncluster/config_sanity.py
+++ b/cli/cfncluster/config_sanity.py
@@ -40,7 +40,9 @@ def check_resource(region, aws_access_key_id, aws_secret_access_key, resource_ty
                                 aws_secret_access_key=aws_secret_access_key)
 
             arn = iam.get_role(RoleName=resource_value).get('Role').get('Arn')
-            accountid = boto3.client('sts').get_caller_identity().get('Account')
+            accountid = boto3.client('sts', region_name=region,
+                                        aws_access_key_id=aws_access_key_id,
+                                        aws_secret_access_key=aws_secret_access_key).get_caller_identity().get('Account')
 
             iam_policy = [(['ec2:DescribeVolumes', 'ec2:AttachVolume', 'ec2:DescribeInstanceAttribute', 'ec2:DescribeInstanceStatus', 'ec2:DescribeInstances'], "*"),
                         (['dynamodb:ListTables'], "*"),


### PR DESCRIPTION
When creating a cluster using a custom `ec2_iam_role`, the sanity check would fail for the `EC2IAMRoleName`, because the credentials were not being provided when instantiating a `boto3` client for a `STS` resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.