### PR TITLE
Add GetTemplate permission to CfnClusterUserPolicy template

### DIFF
--- a/docs/source/iam.rst
+++ b/docs/source/iam.rst
@@ -281,7 +281,8 @@ CfnClusterUserPolicy
                   "cloudformation:DescribeStackResource",
                   "cloudformation:DescribeStackResources",
                   "cloudformation:DescribeStacks",
-                  "cloudformation:ListStacks"
+                  "cloudformation:ListStacks",
+                  "cloudformation:GetTemplate"
               ],
               "Effect": "Allow",
               "Resource": "*"


### PR DESCRIPTION
Updates the docs to add `cloudformation:GetTemplate` permission to `CfnClusterUserPolicy` template in order to allow the user to call `cfncluster ssh`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.