### PR TITLE
Remove lines containing removed cloudwatch metric parameters

### DIFF
--- a/cli/cfncluster/examples/config
+++ b/cli/cfncluster/examples/config
@@ -177,27 +177,6 @@ master_subnet_id = subnet-
 
 ## Scaling settings
 #[scaling custom]
-# Threshold for triggering CloudWatch ScaleUp action
-# (defaults to 1 for default template)
-#scaling_threshold = 1
-# Number of instances to add when called CloudWatch ScaleUp action
-# (defaults to 1 for default template)
-#scaling_adjustment = 1
-# Threshold for triggering CloudWatch ScaleUp2 action
-# (defaults to 200 for default template)
-#scaling_threshold2 = 200
-# Number of instances to add when called CloudWatch ScaleUp2 action
-# (defaults to 20 for default template)
-#scaling_adjustment2 = 20
-# Period to measure ScalingThreshold
-# (defaults to 60 for default template)
-#scaling_period = 60
-# Number of periods to measure ScalingThreshold
-# (defaults to 2 for default template)
-#scaling_evaluation_periods = 2
-# Amount of time in seconds to wait before attempting further scaling actions
-# (defaults to 300 for the default template
-#scaling_cooldown = 300
 # Amount of time in minutes without a job after which the compute node will terminate
 # Defaults to 10 for the default template
 #scaledown_idletime = 10

--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -102,13 +102,6 @@
             "default": "Scaling Settings"
           },
           "Parameters": [
-            "ScalingPeriod",
-            "ScalingEvaluationPeriods",
-            "ScalingThreshold",
-            "ScalingAdjustment",
-            "ScalingThreshold2",
-            "ScalingAdjustment2",
-            "ScalingCooldown",
             "ScaleDownIdleTime"
           ]
         },
@@ -271,24 +264,6 @@
         },
         "EBSVolumeId": {
           "default": "ebs_volume_id"
-        },
-        "ScalingThreshold": {
-          "default": "scaling_threshold"
-        },
-        "ScalingPeriod": {
-          "default": "scaling_period"
-        },
-        "ScalingEvaluationPeriods": {
-          "default": "scaling_evaluation_periods"
-        },
-        "ScalingAdjustment": {
-          "default": "scaling_adjustment"
-        },
-        "ScalingAdjustment2": {
-          "default": "scaling_adjustment2"
-        },
-        "ScalingCooldown": {
-          "default": "scaling_cooldown"
         },
         "ScaleDownIdleTime": {
           "default": "scaledown_idletime"


### PR DESCRIPTION
Remove the lines containing removed cloudwatch metric parameters which were previously used for scaling up.
While parameters were removed by a previous commit, few lines were missed which is being addressed by this commit

Signed-off-by: Balaji Sridharan <fnubalaj@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
