### PR TITLE
docs: move networking configuration title before the architecture diagram

### DIFF
--- a/docs/source/networking.rst
+++ b/docs/source/networking.rst
@@ -13,10 +13,11 @@ All of these configurations can operate with or without public IP addressing. It
 
 Below are some architecture diagrams for some of those scenarios:
 
+CfnCluster in a single public subnet
+------
+
 .. figure:: images/networking_single_subnet.jpg
    :alt: CfnCluster single subnet
-
-   CfnCluster in a single public subnet
 
 The configuration for this architecture requires the following settings:
 
@@ -28,10 +29,11 @@ The configuration for this architecture requires the following settings:
   vpc_id = vpc-a1b2c3d4
   master_subnet_id = subnet-a1b2c3d4
 
+CfnCluster using two subnets (new private)
+------
+
 .. figure:: images/networking_two_subnets.jpg
    :alt: CfnCluster two subnets
-
-   CfnCluster using two subnets (new private)
 
 The configuration for this architecture requires the following settings:
 
@@ -44,10 +46,11 @@ The configuration for this architecture requires the following settings:
   master_subnet_id = subnet-a1b2c3d4
   compute_subnet_cidr = 10.0.1.0/24
 
+CfnCluster in a private subnet connected using Direct Connect
+------
+
 .. figure:: images/networking_private_dx.jpg
    :alt: CfnCluster private with DX
-
-   CfnCluster in a private subnet connected using Direct Connect
 
 The configuration for this architecture requires the following settings:
 


### PR DESCRIPTION
Now the title of the networking configuration type is placed before the architecture image
and the title is highlighted to make the doc more clear.

Old page [here](https://github.com/awslabs/cfncluster/blob/18503b51932fcd18e51a767bdd334ac3191552e3/docs/source/networking.rst) and new rendered page [here](https://github.com/awslabs/cfncluster/blob/af5e4eee20ce2f66936ec3742083106ab2d3e65a/docs/source/networking.rst).