### PR TITLE
Make title underlines length the same as the titles

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -519,7 +519,7 @@ Settings which define how the compute nodes scale. ::
     scaledown_idletime = 10
 
 scaledown_idletime
-""""""""""""""""
+""""""""""""""""""
 Amount of time in minutes without a job after which the compute node will terminate.
 
 Defaults to 10 for the default template. ::

--- a/docs/source/networking.rst
+++ b/docs/source/networking.rst
@@ -14,7 +14,7 @@ All of these configurations can operate with or without public IP addressing. It
 Below are some architecture diagrams for some of those scenarios:
 
 CfnCluster in a single public subnet
-------
+------------------------------------
 
 .. figure:: images/networking_single_subnet.jpg
    :alt: CfnCluster single subnet
@@ -30,7 +30,7 @@ The configuration for this architecture requires the following settings:
   master_subnet_id = subnet-a1b2c3d4
 
 CfnCluster using two subnets (new private)
-------
+------------------------------------------
 
 .. figure:: images/networking_two_subnets.jpg
    :alt: CfnCluster two subnets
@@ -47,7 +47,7 @@ The configuration for this architecture requires the following settings:
   compute_subnet_cidr = 10.0.1.0/24
 
 CfnCluster in a private subnet connected using Direct Connect
-------
+-------------------------------------------------------------
 
 .. figure:: images/networking_private_dx.jpg
    :alt: CfnCluster private with DX


### PR DESCRIPTION
This resolves a warning in the html docs creation:
`cfncluster\docs\source\networking.rst:50: WARNING: Title underline too short.`

http://www.sphinx-doc.org/en/stable/rest.html#sections
