### PR TITLE
Make Spot Price Optional

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -1196,6 +1196,18 @@
         "spot"
       ]
     },
+    "UseSpotPrice": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "SpotPrice"
+            },
+            "0.00"
+          ]
+        }
+      ]
+    },
     "CreateComputeSubnetForCompute": {
       "Fn::And": [
         {
@@ -2965,8 +2977,11 @@
                     "SpotInstanceType" : "one-time",
                     "InstanceInterruptionBehavior" : "terminate",
                     "MaxPrice" : {
-                      "Ref": "SpotPrice"
-                    }
+                      "Fn::If": [
+                      "UseSpotPrice",
+                      { "Ref": "SpotPrice" },
+                      { "Ref": "AWS::NoValue" }
+                    ]}
                 },
                 "MarketType" : "spot"
               },

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -163,7 +163,9 @@ Defaults to ondemand for the default template. ::
 
 spot_price
 """""""""""
-If cluster_type is set to spot, the maximum spot price for the ComputeFleet. See the `Spot Bid Advisor <https://aws.amazon.com/ec2/spot/bid-advisor/>`_ for assistance finding a bid price that meets your needs::
+If cluster_type is set to spot, you can optionally set the maximum spot price for the ComputeFleet. If you do not specify a value, you are charged the Spot price, capped at the On-Demand price.
+
+See the `Spot Bid Advisor <https://aws.amazon.com/ec2/spot/bid-advisor/>`_ for assistance finding a bid price that meets your needs::
 
     spot_price = 0.00
 


### PR DESCRIPTION
#### Background

Spot requests do not require a spot bid price anymore. If you do not specify a spot price in the config, you are charged the current market Spot price, capped at the On-Demand price.  

See https://github.com/awslabs/cfncluster/issues/577

#### Testing

Created a spot cluster with no `spot_price` and one with `spot_price = 1.00` and verified they were set correctly in the launch template.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
