### PR TITLE
Update Config Sanity to Support GovCloud

### DIFF
--- a/cli/cfncluster/config_sanity.py
+++ b/cli/cfncluster/config_sanity.py
@@ -44,15 +44,17 @@ def check_resource(region, cluster_name, aws_access_key_id, aws_secret_access_ke
                                         aws_access_key_id=aws_access_key_id,
                                         aws_secret_access_key=aws_secret_access_key).get_caller_identity().get('Account')
 
+            partition = get_partition(region)
+
             iam_policy = [(['ec2:DescribeVolumes', 'ec2:AttachVolume', 'ec2:DescribeInstanceAttribute', 'ec2:DescribeInstanceStatus', 'ec2:DescribeInstances'], "*"),
                         (['dynamodb:ListTables'], "*"),
-                        (['sqs:SendMessage', 'sqs:ReceiveMessage', 'sqs:ChangeMessageVisibility', 'sqs:DeleteMessage', 'sqs:GetQueueUrl'], "arn:aws:sqs:%s:%s:cfncluster-*" % (region, accountid)),
+                        (['sqs:SendMessage', 'sqs:ReceiveMessage', 'sqs:ChangeMessageVisibility', 'sqs:DeleteMessage', 'sqs:GetQueueUrl'], "arn:%s:sqs:%s:%s:cfncluster-*" % (partition, region, accountid)),
                         (['autoscaling:DescribeAutoScalingGroups', 'autoscaling:TerminateInstanceInAutoScalingGroup', 'autoscaling:SetDesiredCapacity', 'autoscaling:DescribeTags', 'autoScaling:UpdateAutoScalingGroup'], "*"),
-                        (['dynamodb:PutItem', 'dynamodb:Query', 'dynamodb:GetItem', 'dynamodb:DeleteItem', 'dynamodb:DescribeTable'], "arn:aws:dynamodb:%s:%s:table/cfncluster-*" % (region, accountid)),
-                        (['cloudformation:DescribeStacks'], "arn:aws:cloudformation:%s:%s:stack/cfncluster-%s/*" % (region, accountid, cluster_name)),
-                        (['s3:GetObject'], "arn:aws:s3:::%s-cfncluster/*" % region),
+                        (['dynamodb:PutItem', 'dynamodb:Query', 'dynamodb:GetItem', 'dynamodb:DeleteItem', 'dynamodb:DescribeTable'], "arn:%s:dynamodb:%s:%s:table/cfncluster-*" % (partition, region, accountid)),
+                        (['cloudformation:DescribeStacks'], "arn:%s:cloudformation:%s:%s:stack/cfncluster-%s/*" % (partition, region, accountid, cluster_name)),
+                        (['s3:GetObject'], "arn:%s:s3:::%s-cfncluster/*" % (partition, region)),
                         (['sqs:ListQueues'], "*"),
-                        (['logs:*'], "arn:aws:logs:*:*:*")]
+                        (['logs:*'], "arn:%s:logs:*:*:*" % partition)]
 
             for actions, resource_arn in iam_policy:
                 response = iam.simulate_principal_policy(PolicySourceArn=arn, ActionNames=actions, ResourceArns=[resource_arn])


### PR DESCRIPTION
Customers using a custom `ec2_iam_role` will fail config_sanity in govcloud region. This fixes the arns in govcloud region.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
