### PR TITLE
Restore Autoscaling policy for Launch Configuration needed for GovCloud

### DIFF
--- a/docs/source/iam.rst
+++ b/docs/source/iam.rst
@@ -181,6 +181,7 @@ CfnClusterUserPolicy
               "Sid": "AutoScalingDescribe",
               "Action": [
                   "autoscaling:DescribeAutoScalingGroups",
+                  "autoscaling:DescribeLaunchConfigurations",
                   "autoscaling:DescribeAutoScalingInstances"
               ],
               "Effect": "Allow",
@@ -190,6 +191,7 @@ CfnClusterUserPolicy
               "Sid": "AutoScalingModify",
               "Action": [
                   "autoscaling:CreateAutoScalingGroup",
+                  "autoscaling:CreateLaunchConfiguration",
                   "ec2:CreateLaunchTemplate",
                   "ec2:ModifyLaunchTemplate",
                   "ec2:DeleteLaunchTemplate",
@@ -198,6 +200,7 @@ CfnClusterUserPolicy
                   "autoscaling:PutNotificationConfiguration",
                   "autoscaling:UpdateAutoScalingGroup",
                   "autoscaling:PutScalingPolicy",
+                  "autoscaling:DeleteLaunchConfiguration",
                   "autoscaling:DescribeScalingActivities",
                   "autoscaling:DeleteAutoScalingGroup",
                   "autoscaling:DeletePolicy"


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

Policy were removed here https://github.com/awslabs/cfncluster/commit/73173506b154934c755f300d87702893a86a95a2
but then LaunchConfiguration was reverted for GovCloud here https://github.com/awslabs/cfncluster/commit/e917df67a337ecab303b6648e34f1e9f1b32e2b5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
