### PR TITLE
Add missing cloudformation:DescribeStacks policy

### DIFF
--- a/docs/source/iam.rst
+++ b/docs/source/iam.rst
@@ -4,7 +4,7 @@ IAM in CfnCluster
 ========================
 
 .. warning::
-    Between CfnCluster 1.5.3 and 1.6.0 we added a change to the `CfnClusterInstancePolicy` that adds “s3:GetObject” permissions on objects in <REGION>-cfncluster bucket and cloudformation:DescribeStacks" permissions on <REGION>:<ACCOUNT_NAME>:<STACK_NAME>
+    Between CfnCluster 1.5.4 and 1.6.0 we added a change to the `CfnClusterInstancePolicy` that adds “s3:GetObject” permissions on objects in <REGION>-cfncluster bucket and cloudformation:DescribeStacks" permissions on <REGION>:<ACCOUNT_ID>:stack/<STACK_NAME>
     If you're using a custom policy (e.g. you specify "ec2_iam_role" in your config) be sure it includes this new permission.
 
     Between CfnCluster 1.4.2 and 1.5.0 we added a change to the `CfnClusterInstancePolicy` that adds "ec2:DescribeVolumes" permissions. If you're using a custom policy (e.g. you specify "ec2_iam_role" in your config) be sure it includes this new permission.
@@ -105,6 +105,16 @@ CfnClusterInstancePolicy
                   "s3:GetObject"
               ],
               "Sid": "S3GetObj",
+              "Effect": "Allow"
+          },
+          {
+              "Resource": [
+                  "arn:aws:cloudformation:<REGION>:<AWS ACCOUNT ID>:stack/cfncluster-*"
+              ],
+              "Action": [
+                  "cloudformation:DescribeStacks"
+              ],
+              "Sid": "CloudFormationDescribe",
               "Effect": "Allow"
           },
           {


### PR DESCRIPTION
The policy requirement was added here https://github.com/awslabs/cfncluster/commit/8166743a48deb3148f83038262251acfc0be862c
This fix commit https://github.com/awslabs/cfncluster/commit/486a913d29181fe6bbebe76dddee528a7992d77a

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
