### PR TITLE
Remove cluster_name completely while using describe_stacks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,9 +108,9 @@ Changes
 
 CfnCluster 1.6 IAM Change
 =========================
-Between CfnCluster 1.5.3 and 1.6.0 we made a change to the CfnClusterInstancePolicy that adds “s3:GetObject” permissions
+Between CfnCluster 1.5.4 and 1.6.0 we made a change to the CfnClusterInstancePolicy that adds “s3:GetObject” permissions
 on objects in <REGION>-cfncluster bucket, "autoscaling:SetDesiredCapacity", "autoscaling:DescribeTags" permissions and
-"cloudformation:DescribeStacks" permissions on <REGION>:<ACCOUNT_NAME>:<STACK_NAME>.
+"cloudformation:DescribeStacks" permissions on <REGION>:<ACCOUNT_ID>:stack/cfncluster-*.
 
 If you’re using a custom policy (e.g. you specify "ec2_iam_role" in your config) be sure it includes this new permission. See https://cfncluster.readthedocs.io/en/latest/iam.html
 

--- a/cli/cfncluster/cfnconfig.py
+++ b/cli/cfncluster/cfnconfig.py
@@ -153,7 +153,7 @@ class CfnClusterConfig(object):
                 print("ERROR: key_name set in [%s] section but not defined." % self.__cluster_section)
                 sys.exit(1)
             if self.__sanity_check:
-                config_sanity.check_resource(self.region, self.args.cluster_name, self.aws_access_key_id, self.aws_secret_access_key,
+                config_sanity.check_resource(self.region, self.aws_access_key_id, self.aws_secret_access_key,
                                              'EC2KeyPair', self.key_name)
         except configparser.NoOptionError:
             print("ERROR: Missing key_name option in [%s] section." % self.__cluster_section)
@@ -173,7 +173,7 @@ class CfnClusterConfig(object):
                         print("ERROR: template_url set in [%s] section but not defined." % self.__cluster_section)
                         sys.exit(1)
                     if self.__sanity_check:
-                        config_sanity.check_resource(self.region, self.args.cluster_name, self.aws_access_key_id, self.aws_secret_access_key,
+                        config_sanity.check_resource(self.region, self.aws_access_key_id, self.aws_secret_access_key,
                                                      'URL', self.template_url)
                 except configparser.NoOptionError:
                     if self.region == 'us-gov-west-1':
@@ -208,7 +208,7 @@ class CfnClusterConfig(object):
                                                     % (key, self.__vpc_section))
                     sys.exit(1)
                 if self.__sanity_check and self.__vpc_options.get(key)[1] is not None:
-                    config_sanity.check_resource(self.region, self.args.cluster_name, self.aws_access_key_id, self.aws_secret_access_key,
+                    config_sanity.check_resource(self.region, self.aws_access_key_id, self.aws_secret_access_key,
                                                 self.__vpc_options.get(key)[1],__temp__)
                 self.parameters.append((self.__vpc_options.get(key)[0],__temp__))
             except configparser.NoOptionError:
@@ -245,7 +245,7 @@ class CfnClusterConfig(object):
                                                     % (key, self.__cluster_section))
                     sys.exit(1)
                 if self.__sanity_check and self.__cluster_options.get(key)[1] is not None:
-                    config_sanity.check_resource(self.region, self.args.cluster_name, self.aws_access_key_id, self.aws_secret_access_key,
+                    config_sanity.check_resource(self.region, self.aws_access_key_id, self.aws_secret_access_key,
                                                 self.__cluster_options.get(key)[1],__temp__)
                 self.parameters.append((self.__cluster_options.get(key)[0],__temp__))
             except configparser.NoOptionError:
@@ -294,7 +294,7 @@ class CfnClusterConfig(object):
                                                     % (key, self.__ebs_section))
                             sys.exit(1)
                         if self.__sanity_check and self.__ebs_options.get(key)[1] is not None:
-                            config_sanity.check_resource(self.region, self.args.cluster_name, self.aws_access_key_id, self.aws_secret_access_key,
+                            config_sanity.check_resource(self.region, self.aws_access_key_id, self.aws_secret_access_key,
                                                 self.__ebs_options.get(key)[1],__temp__)
                         self.parameters.append((self.__ebs_options.get(key)[0],__temp__))
                     except configparser.NoOptionError:
@@ -326,7 +326,7 @@ class CfnClusterConfig(object):
                                                     % (key, self.__scaling_section))
                             sys.exit(1)
                         if self.__sanity_check and self.__scaling_options.get(key)[1] is not None:
-                            config_sanity.check_resource(self.region, self.args.cluster_name, self.aws_access_key_id, self.aws_secret_access_key,
+                            config_sanity.check_resource(self.region, self.aws_access_key_id, self.aws_secret_access_key,
                                                 self.__scaling_options.get(key)[1],__temp__)
                         self.parameters.append((self.__scaling_options.get(key)[0],__temp__))
                     except configparser.NoOptionError:

--- a/cli/cfncluster/config_sanity.py
+++ b/cli/cfncluster/config_sanity.py
@@ -26,7 +26,7 @@ def get_partition(region):
     return 'aws'
 
 
-def check_resource(region, cluster_name, aws_access_key_id, aws_secret_access_key, resource_type,resource_value):
+def check_resource(region, aws_access_key_id, aws_secret_access_key, resource_type, resource_value):
 
     # Loop over all supported resource checks
     # EC2 KeyPair
@@ -57,12 +57,10 @@ def check_resource(region, cluster_name, aws_access_key_id, aws_secret_access_ke
                         (['sqs:SendMessage', 'sqs:ReceiveMessage', 'sqs:ChangeMessageVisibility', 'sqs:DeleteMessage', 'sqs:GetQueueUrl'], "arn:%s:sqs:%s:%s:cfncluster-*" % (partition, region, accountid)),
                         (['autoscaling:DescribeAutoScalingGroups', 'autoscaling:TerminateInstanceInAutoScalingGroup', 'autoscaling:SetDesiredCapacity', 'autoscaling:DescribeTags', 'autoScaling:UpdateAutoScalingGroup'], "*"),
                         (['dynamodb:PutItem', 'dynamodb:Query', 'dynamodb:GetItem', 'dynamodb:DeleteItem', 'dynamodb:DescribeTable'], "arn:%s:dynamodb:%s:%s:table/cfncluster-*" % (partition, region, accountid)),
+                        (['cloudformation:DescribeStacks'], "arn:%s:cloudformation:%s:%s:stack/cfncluster-*" % (partition, region, accountid)),
                         (['s3:GetObject'], "arn:%s:s3:::%s-cfncluster/*" % (partition, region)),
                         (['sqs:ListQueues'], "*"),
                         (['logs:*'], "arn:%s:logs:*:*:*" % partition)]
-
-            if cluster_name is not None:
-                iam_policy['cloudformation:DescribeStacks'] = "arn:%s:cloudformation:%s:%s:stack/cfncluster-%s/*" % (partition, region, accountid, cluster_name)
 
             for actions, resource_arn in iam_policy:
                 response = iam.simulate_principal_policy(PolicySourceArn=arn, ActionNames=actions, ResourceArns=[resource_arn])

--- a/cli/cfncluster/easyconfig.py
+++ b/cli/cfncluster/easyconfig.py
@@ -177,8 +177,5 @@ def configure(args):
     with open(config_file,'w') as cf:
         config.write(cf)
 
-    # Set cluster name to none, since it is needed by config sanity
-    args.cluster_name = None
-
     # Verify the configuration
     cfnconfig.CfnClusterConfig(args)

--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -1947,11 +1947,7 @@
                       {
                         "Ref": "AWS::AccountId"
                       },
-                      ":stack/",
-                      {
-                        "Ref": "AWS::StackName"
-                      },
-                      "/*"
+                      ":stack/cfncluster-*"
                     ]
                   ]
                 }

--- a/docs/source/iam.rst
+++ b/docs/source/iam.rst
@@ -4,7 +4,7 @@ IAM in CfnCluster
 ========================
 
 .. warning::
-    Between CfnCluster 1.5.4 and 1.6.0 we added a change to the `CfnClusterInstancePolicy` that adds “s3:GetObject” permissions on objects in <REGION>-cfncluster bucket and cloudformation:DescribeStacks" permissions on <REGION>:<ACCOUNT_ID>:stack/<STACK_NAME>
+    Between CfnCluster 1.5.4 and 1.6.0 we added a change to the `CfnClusterInstancePolicy` that adds “s3:GetObject” permissions on objects in <REGION>-cfncluster bucket and cloudformation:DescribeStacks" permissions on <REGION>:<ACCOUNT_ID>:stack/cfncluster-*
     If you're using a custom policy (e.g. you specify "ec2_iam_role" in your config) be sure it includes this new permission.
 
     Between CfnCluster 1.4.2 and 1.5.0 we added a change to the `CfnClusterInstancePolicy` that adds "ec2:DescribeVolumes" permissions. If you're using a custom policy (e.g. you specify "ec2_iam_role" in your config) be sure it includes this new permission.


### PR DESCRIPTION
Prevent changing policy each time a new cluster is created

Signed-off-by: Balaji Sridharan <fnubalaj@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
